### PR TITLE
Added labyrinth domain

### DIFF
--- a/flatten-structure.py
+++ b/flatten-structure.py
@@ -23,6 +23,7 @@ FLAT_DOMAINS = ['genome-edit-distance',
 # Domains that are divided based on structure but have same domain file. Should
 # be flattened into a single domain.
 NOT_FLAT_SAME_DOMAIN = [
+    'labyrinth',
     'blocksworld-large-simple',
     'logistics-large-simple',
     'rovers-large-simple']

--- a/labyrinth/OPT/domain.pddl
+++ b/labyrinth/OPT/domain.pddl
@@ -1,0 +1,497 @@
+(define (domain labyrinth)
+(:requirements :adl :action-costs)
+
+(:types
+    ;; card with 2 to 4 paths
+    card - object
+    direction - object
+    ;; vertical direction: N S
+    directionV - direction
+    ;; horizontal directions: W E
+    directionH - direction
+    ;; values for positions of the card in the grid
+    gridpos - object
+)
+
+(:constants
+    S N - directionV
+    W E - directionH
+)
+
+(:predicates
+    ;; ordering of values for grid positions ?p1 = ?p2 + 1
+    (NEXT ?p1 - gridpos ?p2 - gridpos)
+    ;; maximal grid index
+    (MAX-POS ?p - gridpos)
+    ;; minimal grid index
+    (MIN-POS ?p - gridpos)
+    ;; moving from ?c in direction ?d is blocked by a wall
+    (BLOCKED ?c - card ?d - direction)
+    ;; robot is located on card ?c
+    (robot-at ?c - card)
+    ;; card ?c is positioned in the grid at ?x ?y
+    (card-at ?c - card ?x - gridpos ?y - gridpos)
+    ;; flag indicating that the robot left the maze e.i. that the goal has been reached
+    (left)
+
+    ;; Inverted predicates that are necessary to remove negative preconditions.
+    (not-cards-moving)
+
+    (NOT-BLOCKED ?c - card ?d - direction)
+
+    (not-robot-at ?c - card)
+
+    ;; flag to indicate that a card is currently moving an the robot cannot move
+    (cards-moving)
+    ;; flags to indicate that a row/column is rotating in the corresponding direction
+    (cards-moving-west)
+    (cards-moving-east)
+    (cards-moving-south)
+    (cards-moving-north)
+    ;; the card whose position needs to be updated next while rotating
+    (next-moving-card ?c - card)
+    ;; the card that was removed to rotate and which needs to be placed at the beginning/end of the row/column
+    (new-headtail-card ?c - card)
+
+)
+
+(:functions
+    (total-cost) - number
+    (move-robot-cost) - number
+    (move-card) - number
+)
+
+;; moves the robot between to cards
+(:action move-west
+    :parameters (?cfrom - card ?xfrom - gridpos ?yfrom - gridpos ?dfrom - directionH ?cto - card ?xto - gridpos ?yto - gridpos ?dto - directionH)
+    :precondition
+        (and
+            (not-cards-moving)
+            (= ?dfrom w)
+            (robot-at ?cfrom)
+            (card-at ?cfrom ?xfrom ?yfrom)
+            (card-at ?cto ?xto ?yto)
+            (next ?xfrom ?xto)
+            (= ?yfrom ?yto)
+            (not (= ?dfrom ?dto))
+            (not-blocked ?cfrom ?dfrom)
+            (not-blocked ?cto ?dto)
+        )
+    :effect
+        (and
+            (not (robot-at ?cfrom))
+            (not-robot-at ?cfrom)
+            (not (not-robot-at ?cto))
+            (robot-at ?cto)
+            (increase (total-cost) (move-robot-cost))
+        )
+)
+
+(:action move-east
+    :parameters (?cfrom - card ?xfrom - gridpos ?yfrom - gridpos ?dfrom - directionH ?cto - card ?xto - gridpos ?yto - gridpos ?dto - directionH)
+    :precondition
+        (and
+            (not-cards-moving)
+            (= ?dfrom e)
+            (robot-at ?cfrom)
+            (card-at ?cfrom ?xfrom ?yfrom)
+            (card-at ?cto ?xto ?yto)
+            (next ?xto ?xfrom)
+            (= ?yfrom ?yto)
+            (not (= ?dfrom ?dto))
+            (not-blocked ?cfrom ?dfrom)
+            (not-blocked ?cto ?dto)
+        )
+    :effect
+        (and
+            (not (robot-at ?cfrom))
+            (not-robot-at ?cfrom)
+            (not (not-robot-at ?cto))
+            (robot-at ?cto)
+            (increase (total-cost) (move-robot-cost))
+        )
+)
+
+(:action move-north
+    :parameters (?cfrom - card ?xfrom - gridpos ?yfrom - gridpos ?dfrom - directionV ?cto - card ?xto - gridpos ?yto - gridpos ?dto - directionV)
+    :precondition
+        (and
+            (not-cards-moving)
+            (= ?dfrom n)
+            (robot-at ?cfrom)
+            (card-at ?cfrom ?xfrom ?yfrom)
+            (card-at ?cto ?xto ?yto)
+            (next ?yfrom ?yto)
+            (= ?xfrom ?xto)
+            (not (= ?dfrom ?dto))
+            (not-blocked ?cfrom ?dfrom)
+            (not-blocked ?cto ?dto)
+        )
+    :effect
+        (and
+            (not (robot-at ?cfrom))
+            (not-robot-at ?cfrom)
+            (not (not-robot-at ?cto))
+            (robot-at ?cto)
+            (increase (total-cost) (move-robot-cost))
+        )
+)
+
+(:action move-south
+    :parameters (?cfrom - card ?xfrom - gridpos ?yfrom - gridpos ?dfrom - directionV ?cto - card ?xto - gridpos ?yto - gridpos ?dto - directionV)
+    :precondition
+        (and
+            (not-cards-moving)
+            (= ?dfrom s)
+            (robot-at ?cfrom)
+            (card-at ?cfrom ?xfrom ?yfrom)
+            (card-at ?cto ?xto ?yto)
+            (next ?yto ?yfrom)
+            (= ?xfrom ?xto)
+            (not (= ?dfrom ?dto))
+            (not-blocked ?cfrom ?dfrom)
+            (not-blocked ?cto ?dto)
+        )
+    :effect
+        (and
+            (not (robot-at ?cfrom))
+            (not-robot-at ?cfrom)
+            (not (not-robot-at ?cto))
+            (robot-at ?cto)
+            (increase (total-cost) (move-robot-cost))
+        )
+)
+
+
+;; there 3 (start, move, stop) for each direction to rotate the cards
+;; rotating ends in a deadend if the card with the robot in the row/column that is rotated
+;; ----------------------------------------------------------------------------------------
+
+;; starts rotation
+;; saves the card with the minimal index
+;; determines which card should be updated next the corresponding move action
+;; and makes all other actions inapplicable by setting cards-moving and cards-moving-west
+(:action start-move-card-west
+:parameters(?cm - card ?x - gridpos ?y - gridpos ?cnext - card ?nextx - gridpos)
+:precondition
+    (and
+        (not-cards-moving)
+        (not-robot-at ?cm)
+        (card-at ?cm ?x ?y )
+        (min-pos ?x)
+        (card-at ?cnext ?nextx ?y)
+        (next ?nextx ?x)
+    )
+:effect
+    (and
+        (cards-moving)
+        (cards-moving-west)
+        (not (not-cards-moving))
+        (not (card-at ?cm ?x ?y ))
+        (new-headtail-card ?cm)
+        (next-moving-card ?cnext)
+        (increase (total-cost) (move-card))
+    )
+)
+
+;; updates the grid column index of ?cm which is the next card to update
+(:action move-card-west
+:parameters(?cm - card ?x - gridpos ?y - gridpos ?cnext - card ?nextx - gridpos ?prevx - gridpos)
+:precondition
+    (and
+        (cards-moving)
+        (cards-moving-west)
+        (not-robot-at ?cm)
+        (next-moving-card ?cm)
+        (card-at ?cm ?x ?y )
+        (card-at ?cnext ?nextx ?y)
+        (next ?x ?prevx)
+        (next ?nextx ?x)
+    )
+:effect
+    (and
+        (cards-moving)
+        (cards-moving-west)
+        (not (card-at ?cm ?x ?y))
+        (card-at ?cm ?prevx ?y)
+        (not (next-moving-card ?cm))
+        (next-moving-card ?cnext)
+    )
+)
+
+;; stops rotation
+;; updates the grid index of the card specified by the start move action in new-headtail-card
+(:action stop-move-card-west
+:parameters(?cm - card ?x - gridpos ?y - gridpos ?prevx - gridpos ?newtc - card)
+:precondition
+    (and
+        (cards-moving)
+        (cards-moving-west)
+        (not-robot-at ?cm)
+        (next-moving-card ?cm)
+        (card-at ?cm ?x ?y )
+        (next ?x ?prevx)
+        (max-pos ?x)
+        (new-headtail-card ?newtc)
+    )
+:effect
+    (and
+        (not-cards-moving)
+        (not (cards-moving))
+        (not (cards-moving-west))
+        (not (card-at ?cm ?x ?y))
+        (card-at ?cm ?prevx ?y)
+        (card-at ?newtc ?x ?y)
+        (not (new-headtail-card ?newtc))
+        (not (next-moving-card ?cm))
+    )
+)
+
+
+;; ----------------------------------------------------------------------------------------
+
+(:action start-move-card-east
+:parameters(?cm - card ?x - gridpos ?y - gridpos ?cnext - card ?nextx - gridpos)
+:precondition
+    (and
+        (not-cards-moving)
+        (not-robot-at ?cm)
+        (card-at ?cm ?x ?y )
+        (max-pos ?x)
+        (card-at ?cnext ?nextx ?y)
+        (next ?x ?nextx)
+    )
+:effect
+    (and
+        (not (not-cards-moving))
+        (cards-moving)
+        (cards-moving-east)
+        (not (card-at ?cm ?x ?y ))
+        (new-headtail-card ?cm)
+        (next-moving-card ?cnext)
+        (increase (total-cost) (move-card))
+    )
+)
+
+(:action move-card-east
+:parameters(?cm - card ?x - gridpos ?y - gridpos ?cnext - card ?nextx - gridpos ?prevx - gridpos)
+:precondition
+    (and
+        (cards-moving)
+        (cards-moving-east)
+        (not-robot-at ?cm)
+        (next-moving-card ?cm)
+        (card-at ?cm ?x ?y )
+        (card-at ?cnext ?nextx ?y)
+        (next ?prevx ?x)
+        (next ?x ?nextx)
+    )
+:effect
+    (and
+        (cards-moving)
+        (cards-moving-east)
+        (not (card-at ?cm ?x ?y))
+        (card-at ?cm ?prevx ?y)
+        (not (next-moving-card ?cm))
+        (next-moving-card ?cnext)
+    )
+)
+
+(:action stop-move-card-east
+:parameters(?cm - card ?x - gridpos ?y - gridpos ?prevx - gridpos ?newtc - card)
+:precondition
+    (and
+        (cards-moving)
+        (cards-moving-east)
+        (not-robot-at ?cm)
+        (next-moving-card ?cm)
+        (card-at ?cm ?x ?y )
+        (next  ?prevx ?x)
+        (min-pos ?x)
+        (new-headtail-card ?newtc)
+    )
+:effect
+    (and
+        (not-cards-moving)
+        (not (cards-moving))
+        (not (cards-moving-east))
+        (not (card-at ?cm ?x ?y))
+        (card-at ?cm ?prevx ?y)
+        (card-at ?newtc ?x ?y)
+        (not (new-headtail-card ?newtc))
+        (not (next-moving-card ?cm))
+    )
+)
+
+;; ----------------------------------------------------------------------------------------
+
+(:action start-move-card-north
+:parameters(?cm - card ?x - gridpos ?y - gridpos ?cnext - card ?nexty - gridpos)
+:precondition
+    (and
+        (not-cards-moving)
+        (not-robot-at ?cm)
+        (card-at ?cm ?x ?y )
+        (min-pos ?y)
+        (card-at ?cnext ?x ?nexty)
+        (next ?nexty ?y)
+    )
+:effect
+    (and
+        (not (not-cards-moving))
+        (cards-moving)
+        (cards-moving-north)
+        (not (card-at ?cm ?x ?y ))
+        (new-headtail-card ?cm)
+        (next-moving-card ?cnext)
+        (increase (total-cost) (move-card))
+    )
+)
+
+(:action move-card-north
+:parameters(?cm - card ?x - gridpos ?y - gridpos  ?cnext - card ?nexty - gridpos ?prevy - gridpos)
+:precondition
+    (and
+        (cards-moving)
+        (cards-moving-north)
+        (not-robot-at ?cm)
+        (next-moving-card ?cm)
+        (card-at ?cm ?x ?y )
+        (card-at ?cnext ?x ?nexty)
+        (next ?y ?prevy)
+        (next ?nexty ?y)
+    )
+:effect
+    (and
+        (cards-moving)
+        (cards-moving-north)
+        (not (card-at ?cm ?x ?y))
+        (card-at ?cm ?x ?prevy)
+        (not (next-moving-card ?cm))
+        (next-moving-card ?cnext)
+    )
+)
+
+(:action stop-move-card-north
+:parameters(?cm - card ?x - gridpos ?y - gridpos ?prevy - gridpos ?newtc - card)
+:precondition
+    (and
+        (cards-moving)
+        (cards-moving-north)
+        (not-robot-at ?cm)
+        (next-moving-card ?cm)
+        (card-at ?cm ?x ?y )
+        (next ?y ?prevy)
+        (max-pos ?y)
+        (new-headtail-card ?newtc)
+    )
+:effect
+    (and
+        (not-cards-moving)
+        (not (cards-moving))
+        (not (cards-moving-north))
+        (not (card-at ?cm ?x ?y))
+        (card-at ?cm ?x ?prevy)
+        (card-at ?newtc ?x ?y)
+        (not (new-headtail-card ?newtc))
+        (not (next-moving-card ?cm))
+    )
+)
+
+;; ----------------------------------------------------------------------------------------
+
+(:action start-move-card-south
+:parameters(?cm - card ?x - gridpos ?y - gridpos  ?cnext - card ?nexty - gridpos)
+:precondition
+    (and
+        (not-cards-moving)
+        (not-robot-at ?cm)
+        (card-at ?cm ?x ?y )
+        (max-pos ?y)
+        (card-at ?cnext ?x ?nexty)
+        (next ?y ?nexty)
+    )
+:effect
+    (and
+        (cards-moving)
+        (cards-moving-south)
+        (not (not-cards-moving))
+        (not (card-at ?cm ?x ?y ))
+        (new-headtail-card ?cm)
+        (next-moving-card ?cnext)
+        (increase (total-cost) (move-card))
+    )
+)
+
+(:action move-card-south
+:parameters(?cm - card ?x - gridpos ?y - gridpos  ?cnext - card ?nexty - gridpos ?prevy - gridpos)
+:precondition
+    (and
+        (cards-moving)
+        (cards-moving-south)
+        (not-robot-at ?cm)
+        (next-moving-card ?cm)
+        (card-at ?cm ?x ?y )
+        (card-at ?cnext ?x ?nexty)
+        (next ?prevy ?y)
+        (next ?y ?nexty)
+    )
+:effect
+    (and
+        (cards-moving)
+        (cards-moving-south)
+        (not (card-at ?cm ?x ?y))
+        (card-at ?cm ?x ?prevy)
+        (not (next-moving-card ?cm))
+        (next-moving-card ?cnext)
+    )
+)
+
+(:action stop-move-card-south
+:parameters(?cm - card ?x - gridpos ?y - gridpos ?prevy - gridpos ?newtc - card)
+:precondition
+    (and
+        (cards-moving)
+        (cards-moving-south)
+        (not-robot-at ?cm)
+        (next-moving-card ?cm)
+        (card-at ?cm ?x ?y )
+        (next ?prevy ?y)
+        (min-pos ?y)
+        (new-headtail-card ?newtc)
+    )
+:effect
+    (and
+        (not-cards-moving)
+        (not (cards-moving))
+        (not (cards-moving-south))
+        (not (card-at ?cm ?x ?y))
+        (card-at ?cm ?x ?prevy)
+        (card-at ?newtc ?x ?y)
+        (not (new-headtail-card ?newtc))
+        (not (next-moving-card ?cm))
+    )
+)
+
+
+;; checks whether the robot can leave the labyrinth i.e
+;; whether the card the robot is currently on is in the bottom right corner
+;; and the rover is in sector SE
+(:action leave
+:parameters(?c - card ?prow - gridpos ?pcolumn - gridpos)
+:precondition
+    (and
+        (not-cards-moving)
+        (robot-at ?c)
+        (card-at ?c ?prow ?pcolumn)
+        (max-pos ?prow)
+        (max-pos ?pcolumn)
+        (not-blocked ?c s )
+    )
+:effect
+    (and
+        (left)
+    )
+)
+)
+

--- a/labyrinth/OPT/p01.pddl
+++ b/labyrinth/OPT/p01.pddl
@@ -1,0 +1,101 @@
+;; Generated with seed: 1229, size: 3, num-rotations: 1
+(define (problem labyrinth-size-3-rotations-1-seed-1229)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8  - card
+)
+(:init
+	(NOT-BLOCKED card8 W)
+	(NOT-BLOCKED card8 S)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 E)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 W)
+	(NOT-BLOCKED card6 N)
+
+	(NOT-BLOCKED card5 W)
+	(NOT-BLOCKED card5 S)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 S)
+	(NOT-BLOCKED card4 E)
+	(NOT-BLOCKED card4 N)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 S)
+	(NOT-BLOCKED card3 E)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 S)
+	(NOT-BLOCKED card2 E)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 S)
+	(NOT-BLOCKED card1 E)
+
+	(NOT-BLOCKED card0 W)
+	(NOT-BLOCKED card0 S)
+	(NOT-BLOCKED card0 E)
+
+	(MAX-POS pos2)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+
+	(card-at card0 pos0 pos0)
+	(card-at card4 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card3 pos0 pos1)
+	(card-at card7 pos1 pos1)
+	(card-at card5 pos2 pos1)
+	(card-at card6 pos0 pos2)
+	(card-at card1 pos1 pos2)
+	(card-at card8 pos2 pos2)
+
+	(BLOCKED card0 N)
+
+	(BLOCKED card4 W)
+
+	(BLOCKED card2 N)
+
+	(BLOCKED card3 N)
+
+	(BLOCKED card7 S)
+	(BLOCKED card7 W)
+
+	(BLOCKED card5 E)
+
+	(BLOCKED card6 E)
+	(BLOCKED card6 S)
+
+	(BLOCKED card1 N)
+
+	(BLOCKED card8 E)
+
+
+	(robot-at card0)
+
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/OPT/p02.pddl
+++ b/labyrinth/OPT/p02.pddl
@@ -1,0 +1,158 @@
+;; Generated with seed: 1231, size: 4, num-rotations: 2
+(define (problem labyrinth-size-4-rotations-2-seed-1231)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15  - card
+)
+(:init
+	(NOT-BLOCKED card15 S)
+	(NOT-BLOCKED card15 E)
+	(NOT-BLOCKED card15 N)
+
+	(NOT-BLOCKED card14 W)
+	(NOT-BLOCKED card14 S)
+	(NOT-BLOCKED card14 E)
+	(NOT-BLOCKED card14 N)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 S)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 S)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 W)
+	(NOT-BLOCKED card11 S)
+
+	(NOT-BLOCKED card10 S)
+	(NOT-BLOCKED card10 E)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 E)
+	(NOT-BLOCKED card9 N)
+
+	(NOT-BLOCKED card8 E)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 W)
+	(NOT-BLOCKED card6 S)
+
+	(NOT-BLOCKED card5 E)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 E)
+	(NOT-BLOCKED card4 N)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 E)
+	(NOT-BLOCKED card3 N)
+
+	(NOT-BLOCKED card2 S)
+	(NOT-BLOCKED card2 E)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 S)
+
+	(NOT-BLOCKED card0 W)
+	(NOT-BLOCKED card0 E)
+
+	(MAX-POS pos3)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+
+	(card-at card0 pos0 pos0)
+	(card-at card5 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card4 pos0 pos1)
+	(card-at card9 pos1 pos1)
+	(card-at card6 pos2 pos1)
+	(card-at card7 pos3 pos1)
+	(card-at card11 pos0 pos2)
+	(card-at card8 pos1 pos2)
+	(card-at card13 pos2 pos2)
+	(card-at card10 pos3 pos2)
+	(card-at card12 pos0 pos3)
+	(card-at card1 pos1 pos3)
+	(card-at card14 pos2 pos3)
+	(card-at card15 pos3 pos3)
+
+	(BLOCKED card0 N)
+	(BLOCKED card0 S)
+
+	(BLOCKED card5 S)
+	(BLOCKED card5 W)
+
+	(BLOCKED card2 N)
+	(BLOCKED card2 W)
+
+	(BLOCKED card3 S)
+
+	(BLOCKED card4 S)
+
+	(BLOCKED card9 S)
+	(BLOCKED card9 W)
+
+	(BLOCKED card6 N)
+	(BLOCKED card6 E)
+
+	(BLOCKED card7 E)
+	(BLOCKED card7 W)
+
+	(BLOCKED card11 N)
+	(BLOCKED card11 E)
+
+	(BLOCKED card8 S)
+	(BLOCKED card8 W)
+
+	(BLOCKED card13 E)
+
+	(BLOCKED card10 W)
+
+	(BLOCKED card12 E)
+	(BLOCKED card12 W)
+
+	(BLOCKED card1 N)
+	(BLOCKED card1 E)
+
+
+	(BLOCKED card15 W)
+
+
+	(robot-at card0)
+
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/OPT/p03.pddl
+++ b/labyrinth/OPT/p03.pddl
@@ -1,0 +1,158 @@
+;; Generated with seed: 1237, size: 4, num-rotations: 3
+(define (problem labyrinth-size-4-rotations-3-seed-1237)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15  - card
+)
+(:init
+	(NOT-BLOCKED card15 S)
+	(NOT-BLOCKED card15 E)
+	(NOT-BLOCKED card15 N)
+
+	(NOT-BLOCKED card14 S)
+	(NOT-BLOCKED card14 E)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 E)
+
+	(NOT-BLOCKED card12 S)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 S)
+	(NOT-BLOCKED card11 E)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 W)
+	(NOT-BLOCKED card10 E)
+
+	(NOT-BLOCKED card9 S)
+	(NOT-BLOCKED card9 N)
+
+	(NOT-BLOCKED card8 S)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 W)
+	(NOT-BLOCKED card6 E)
+
+	(NOT-BLOCKED card5 S)
+	(NOT-BLOCKED card5 E)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 N)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 S)
+	(NOT-BLOCKED card3 N)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 E)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 E)
+
+	(NOT-BLOCKED card0 E)
+	(NOT-BLOCKED card0 N)
+
+	(MAX-POS pos3)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+
+	(card-at card0 pos0 pos0)
+	(card-at card5 pos1 pos0)
+	(card-at card14 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card4 pos0 pos1)
+	(card-at card8 pos1 pos1)
+	(card-at card2 pos2 pos1)
+	(card-at card7 pos3 pos1)
+	(card-at card11 pos0 pos2)
+	(card-at card13 pos1 pos2)
+	(card-at card6 pos2 pos2)
+	(card-at card10 pos3 pos2)
+	(card-at card12 pos0 pos3)
+	(card-at card1 pos1 pos3)
+	(card-at card9 pos2 pos3)
+	(card-at card15 pos3 pos3)
+
+	(BLOCKED card0 S)
+	(BLOCKED card0 W)
+
+	(BLOCKED card5 N)
+	(BLOCKED card5 W)
+
+	(BLOCKED card14 N)
+	(BLOCKED card14 W)
+
+	(BLOCKED card3 E)
+
+	(BLOCKED card4 E)
+	(BLOCKED card4 S)
+
+	(BLOCKED card8 E)
+	(BLOCKED card8 W)
+
+	(BLOCKED card2 N)
+	(BLOCKED card2 S)
+
+	(BLOCKED card7 E)
+	(BLOCKED card7 W)
+
+	(BLOCKED card11 W)
+
+	(BLOCKED card13 N)
+	(BLOCKED card13 S)
+
+	(BLOCKED card6 N)
+	(BLOCKED card6 S)
+
+	(BLOCKED card10 N)
+	(BLOCKED card10 S)
+
+	(BLOCKED card12 E)
+	(BLOCKED card12 W)
+
+	(BLOCKED card1 N)
+	(BLOCKED card1 S)
+
+	(BLOCKED card9 E)
+	(BLOCKED card9 W)
+
+	(BLOCKED card15 W)
+
+
+	(robot-at card0)
+
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/OPT/p04.pddl
+++ b/labyrinth/OPT/p04.pddl
@@ -1,0 +1,158 @@
+;; Generated with seed: 1249, size: 4, num-rotations: 4
+(define (problem labyrinth-size-4-rotations-4-seed-1249)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15  - card
+)
+(:init
+	(NOT-BLOCKED card15 W)
+	(NOT-BLOCKED card15 S)
+
+	(NOT-BLOCKED card14 E)
+	(NOT-BLOCKED card14 N)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 W)
+	(NOT-BLOCKED card12 E)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 W)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 S)
+	(NOT-BLOCKED card10 E)
+
+	(NOT-BLOCKED card9 W)
+	(NOT-BLOCKED card9 S)
+	(NOT-BLOCKED card9 E)
+	(NOT-BLOCKED card9 N)
+
+	(NOT-BLOCKED card8 E)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 W)
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 W)
+	(NOT-BLOCKED card6 E)
+
+	(NOT-BLOCKED card5 E)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 S)
+	(NOT-BLOCKED card4 N)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 S)
+	(NOT-BLOCKED card3 N)
+
+	(NOT-BLOCKED card2 E)
+	(NOT-BLOCKED card2 N)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 S)
+
+	(NOT-BLOCKED card0 S)
+	(NOT-BLOCKED card0 E)
+
+	(MAX-POS pos3)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+
+	(card-at card0 pos0 pos0)
+	(card-at card13 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card1 pos0 pos1)
+	(card-at card6 pos1 pos1)
+	(card-at card7 pos2 pos1)
+	(card-at card4 pos3 pos1)
+	(card-at card10 pos0 pos2)
+	(card-at card11 pos1 pos2)
+	(card-at card8 pos2 pos2)
+	(card-at card5 pos3 pos2)
+	(card-at card12 pos0 pos3)
+	(card-at card9 pos1 pos3)
+	(card-at card14 pos2 pos3)
+	(card-at card15 pos3 pos3)
+
+	(BLOCKED card0 N)
+	(BLOCKED card0 W)
+
+	(BLOCKED card13 E)
+	(BLOCKED card13 S)
+
+	(BLOCKED card2 S)
+	(BLOCKED card2 W)
+
+	(BLOCKED card3 E)
+
+	(BLOCKED card1 N)
+	(BLOCKED card1 E)
+
+	(BLOCKED card6 N)
+	(BLOCKED card6 S)
+
+	(BLOCKED card7 E)
+
+	(BLOCKED card4 E)
+	(BLOCKED card4 W)
+
+	(BLOCKED card10 N)
+	(BLOCKED card10 W)
+
+	(BLOCKED card11 E)
+	(BLOCKED card11 S)
+
+	(BLOCKED card8 S)
+	(BLOCKED card8 W)
+
+	(BLOCKED card5 S)
+	(BLOCKED card5 W)
+
+	(BLOCKED card12 S)
+
+
+	(BLOCKED card14 S)
+	(BLOCKED card14 W)
+
+	(BLOCKED card15 N)
+	(BLOCKED card15 E)
+
+
+	(robot-at card0)
+
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/OPT/p05.pddl
+++ b/labyrinth/OPT/p05.pddl
@@ -1,0 +1,158 @@
+;; Generated with seed: 1259, size: 4, num-rotations: 5
+(define (problem labyrinth-size-4-rotations-5-seed-1259)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15  - card
+)
+(:init
+	(NOT-BLOCKED card15 W)
+	(NOT-BLOCKED card15 S)
+
+	(NOT-BLOCKED card14 E)
+	(NOT-BLOCKED card14 N)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 W)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 W)
+	(NOT-BLOCKED card11 S)
+
+	(NOT-BLOCKED card10 S)
+	(NOT-BLOCKED card10 E)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 S)
+	(NOT-BLOCKED card9 E)
+	(NOT-BLOCKED card9 N)
+
+	(NOT-BLOCKED card8 W)
+	(NOT-BLOCKED card8 S)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 W)
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 E)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 S)
+	(NOT-BLOCKED card6 E)
+
+	(NOT-BLOCKED card5 E)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 E)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 S)
+	(NOT-BLOCKED card3 N)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 S)
+	(NOT-BLOCKED card2 E)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 E)
+
+	(NOT-BLOCKED card0 E)
+	(NOT-BLOCKED card0 N)
+
+	(MAX-POS pos3)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+
+	(card-at card0 pos0 pos0)
+	(card-at card4 pos1 pos0)
+	(card-at card5 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card2 pos0 pos1)
+	(card-at card7 pos1 pos1)
+	(card-at card9 pos2 pos1)
+	(card-at card6 pos3 pos1)
+	(card-at card8 pos0 pos2)
+	(card-at card13 pos1 pos2)
+	(card-at card10 pos2 pos2)
+	(card-at card11 pos3 pos2)
+	(card-at card12 pos0 pos3)
+	(card-at card1 pos1 pos3)
+	(card-at card14 pos2 pos3)
+	(card-at card15 pos3 pos3)
+
+	(BLOCKED card0 S)
+	(BLOCKED card0 W)
+
+	(BLOCKED card4 N)
+	(BLOCKED card4 S)
+
+	(BLOCKED card5 S)
+	(BLOCKED card5 W)
+
+	(BLOCKED card3 E)
+
+	(BLOCKED card2 N)
+
+
+	(BLOCKED card9 W)
+
+	(BLOCKED card6 N)
+	(BLOCKED card6 W)
+
+	(BLOCKED card8 E)
+
+	(BLOCKED card13 E)
+	(BLOCKED card13 S)
+
+	(BLOCKED card10 W)
+
+	(BLOCKED card11 N)
+	(BLOCKED card11 E)
+
+	(BLOCKED card12 E)
+	(BLOCKED card12 S)
+
+	(BLOCKED card1 N)
+	(BLOCKED card1 S)
+
+	(BLOCKED card14 S)
+	(BLOCKED card14 W)
+
+	(BLOCKED card15 N)
+	(BLOCKED card15 E)
+
+
+	(robot-at card0)
+
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/OPT/p06.pddl
+++ b/labyrinth/OPT/p06.pddl
@@ -1,0 +1,231 @@
+;; Generated with seed: 1277, size: 5, num-rotations: 1
+(define (problem labyrinth-size-5-rotations-1-seed-1277)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24  - card
+)
+(:init
+	(NOT-BLOCKED card24 W)
+	(NOT-BLOCKED card24 S)
+
+	(NOT-BLOCKED card23 W)
+	(NOT-BLOCKED card23 E)
+	(NOT-BLOCKED card23 N)
+
+	(NOT-BLOCKED card22 W)
+	(NOT-BLOCKED card22 S)
+
+	(NOT-BLOCKED card21 S)
+	(NOT-BLOCKED card21 E)
+
+	(NOT-BLOCKED card20 W)
+	(NOT-BLOCKED card20 E)
+
+	(NOT-BLOCKED card19 S)
+	(NOT-BLOCKED card19 N)
+
+	(NOT-BLOCKED card18 S)
+	(NOT-BLOCKED card18 N)
+
+	(NOT-BLOCKED card17 W)
+	(NOT-BLOCKED card17 N)
+
+	(NOT-BLOCKED card16 W)
+	(NOT-BLOCKED card16 E)
+	(NOT-BLOCKED card16 N)
+
+	(NOT-BLOCKED card15 W)
+	(NOT-BLOCKED card15 E)
+
+	(NOT-BLOCKED card14 W)
+	(NOT-BLOCKED card14 N)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 S)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 W)
+	(NOT-BLOCKED card12 S)
+
+	(NOT-BLOCKED card11 W)
+	(NOT-BLOCKED card11 S)
+
+	(NOT-BLOCKED card10 S)
+	(NOT-BLOCKED card10 E)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 E)
+	(NOT-BLOCKED card9 N)
+
+	(NOT-BLOCKED card8 W)
+	(NOT-BLOCKED card8 S)
+	(NOT-BLOCKED card8 E)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 E)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 W)
+	(NOT-BLOCKED card6 S)
+	(NOT-BLOCKED card6 E)
+	(NOT-BLOCKED card6 N)
+
+	(NOT-BLOCKED card5 W)
+	(NOT-BLOCKED card5 E)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 S)
+	(NOT-BLOCKED card4 N)
+
+	(NOT-BLOCKED card3 E)
+	(NOT-BLOCKED card3 N)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 S)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 S)
+	(NOT-BLOCKED card1 E)
+
+	(NOT-BLOCKED card0 W)
+	(NOT-BLOCKED card0 E)
+
+	(MAX-POS pos4)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card8 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card5 pos0 pos1)
+	(card-at card6 pos1 pos1)
+	(card-at card7 pos2 pos1)
+	(card-at card13 pos3 pos1)
+	(card-at card9 pos4 pos1)
+	(card-at card10 pos0 pos2)
+	(card-at card11 pos1 pos2)
+	(card-at card12 pos2 pos2)
+	(card-at card18 pos3 pos2)
+	(card-at card14 pos4 pos2)
+	(card-at card15 pos0 pos3)
+	(card-at card16 pos1 pos3)
+	(card-at card17 pos2 pos3)
+	(card-at card23 pos3 pos3)
+	(card-at card19 pos4 pos3)
+	(card-at card20 pos0 pos4)
+	(card-at card21 pos1 pos4)
+	(card-at card22 pos2 pos4)
+	(card-at card3 pos3 pos4)
+	(card-at card24 pos4 pos4)
+
+	(BLOCKED card0 N)
+	(BLOCKED card0 S)
+
+	(BLOCKED card1 N)
+
+	(BLOCKED card2 N)
+	(BLOCKED card2 E)
+
+
+	(BLOCKED card4 E)
+	(BLOCKED card4 W)
+
+	(BLOCKED card5 S)
+
+
+	(BLOCKED card7 W)
+
+	(BLOCKED card13 E)
+
+	(BLOCKED card9 S)
+	(BLOCKED card9 W)
+
+	(BLOCKED card10 W)
+
+	(BLOCKED card11 N)
+	(BLOCKED card11 E)
+
+	(BLOCKED card12 N)
+	(BLOCKED card12 E)
+
+	(BLOCKED card18 E)
+	(BLOCKED card18 W)
+
+	(BLOCKED card14 E)
+	(BLOCKED card14 S)
+
+	(BLOCKED card15 N)
+	(BLOCKED card15 S)
+
+	(BLOCKED card16 S)
+
+	(BLOCKED card17 E)
+	(BLOCKED card17 S)
+
+	(BLOCKED card23 S)
+
+	(BLOCKED card19 E)
+	(BLOCKED card19 W)
+
+	(BLOCKED card20 N)
+	(BLOCKED card20 S)
+
+	(BLOCKED card21 N)
+	(BLOCKED card21 W)
+
+	(BLOCKED card22 N)
+	(BLOCKED card22 E)
+
+	(BLOCKED card3 S)
+	(BLOCKED card3 W)
+
+	(BLOCKED card24 N)
+	(BLOCKED card24 E)
+
+
+	(robot-at card0)
+
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/OPT/p07.pddl
+++ b/labyrinth/OPT/p07.pddl
@@ -1,0 +1,231 @@
+;; Generated with seed: 1279, size: 5, num-rotations: 2
+(define (problem labyrinth-size-5-rotations-2-seed-1279)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24  - card
+)
+(:init
+	(NOT-BLOCKED card24 W)
+	(NOT-BLOCKED card24 S)
+
+	(NOT-BLOCKED card23 W)
+	(NOT-BLOCKED card23 E)
+
+	(NOT-BLOCKED card22 W)
+	(NOT-BLOCKED card22 S)
+	(NOT-BLOCKED card22 E)
+
+	(NOT-BLOCKED card21 W)
+	(NOT-BLOCKED card21 E)
+
+	(NOT-BLOCKED card20 E)
+	(NOT-BLOCKED card20 N)
+
+	(NOT-BLOCKED card19 W)
+	(NOT-BLOCKED card19 E)
+
+	(NOT-BLOCKED card18 W)
+	(NOT-BLOCKED card18 E)
+
+	(NOT-BLOCKED card17 E)
+	(NOT-BLOCKED card17 N)
+
+	(NOT-BLOCKED card16 W)
+	(NOT-BLOCKED card16 S)
+	(NOT-BLOCKED card16 N)
+
+	(NOT-BLOCKED card15 W)
+	(NOT-BLOCKED card15 S)
+	(NOT-BLOCKED card15 E)
+
+	(NOT-BLOCKED card14 W)
+	(NOT-BLOCKED card14 N)
+
+	(NOT-BLOCKED card13 S)
+	(NOT-BLOCKED card13 E)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 W)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 W)
+	(NOT-BLOCKED card11 S)
+	(NOT-BLOCKED card11 E)
+
+	(NOT-BLOCKED card10 W)
+	(NOT-BLOCKED card10 E)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 S)
+	(NOT-BLOCKED card9 E)
+
+	(NOT-BLOCKED card8 W)
+	(NOT-BLOCKED card8 S)
+	(NOT-BLOCKED card8 E)
+
+	(NOT-BLOCKED card7 E)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 W)
+	(NOT-BLOCKED card6 S)
+	(NOT-BLOCKED card6 E)
+
+	(NOT-BLOCKED card5 W)
+	(NOT-BLOCKED card5 S)
+	(NOT-BLOCKED card5 E)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 S)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 E)
+	(NOT-BLOCKED card3 N)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 N)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 S)
+	(NOT-BLOCKED card1 E)
+
+	(NOT-BLOCKED card0 W)
+	(NOT-BLOCKED card0 S)
+	(NOT-BLOCKED card0 E)
+	(NOT-BLOCKED card0 N)
+
+	(MAX-POS pos4)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card22 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card5 pos0 pos1)
+	(card-at card6 pos1 pos1)
+	(card-at card2 pos2 pos1)
+	(card-at card8 pos3 pos1)
+	(card-at card9 pos4 pos1)
+	(card-at card10 pos0 pos2)
+	(card-at card11 pos1 pos2)
+	(card-at card7 pos2 pos2)
+	(card-at card13 pos3 pos2)
+	(card-at card14 pos4 pos2)
+	(card-at card19 pos0 pos3)
+	(card-at card15 pos1 pos3)
+	(card-at card16 pos2 pos3)
+	(card-at card12 pos3 pos3)
+	(card-at card18 pos4 pos3)
+	(card-at card20 pos0 pos4)
+	(card-at card21 pos1 pos4)
+	(card-at card17 pos2 pos4)
+	(card-at card23 pos3 pos4)
+	(card-at card24 pos4 pos4)
+
+
+	(BLOCKED card1 N)
+
+	(BLOCKED card22 N)
+
+	(BLOCKED card3 S)
+
+	(BLOCKED card4 N)
+	(BLOCKED card4 E)
+
+
+	(BLOCKED card6 N)
+
+	(BLOCKED card2 E)
+	(BLOCKED card2 S)
+
+	(BLOCKED card8 N)
+
+	(BLOCKED card9 N)
+	(BLOCKED card9 W)
+
+	(BLOCKED card10 S)
+
+	(BLOCKED card11 N)
+
+	(BLOCKED card7 S)
+	(BLOCKED card7 W)
+
+	(BLOCKED card13 W)
+
+	(BLOCKED card14 E)
+	(BLOCKED card14 S)
+
+	(BLOCKED card19 N)
+	(BLOCKED card19 S)
+
+	(BLOCKED card15 N)
+
+	(BLOCKED card16 E)
+
+	(BLOCKED card12 E)
+	(BLOCKED card12 S)
+
+	(BLOCKED card18 N)
+	(BLOCKED card18 S)
+
+	(BLOCKED card20 S)
+	(BLOCKED card20 W)
+
+	(BLOCKED card21 N)
+	(BLOCKED card21 S)
+
+	(BLOCKED card17 S)
+	(BLOCKED card17 W)
+
+	(BLOCKED card23 N)
+	(BLOCKED card23 S)
+
+	(BLOCKED card24 N)
+	(BLOCKED card24 E)
+
+
+	(robot-at card0)
+
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/OPT/p08.pddl
+++ b/labyrinth/OPT/p08.pddl
@@ -1,0 +1,231 @@
+;; Generated with seed: 1283, size: 5, num-rotations: 3
+(define (problem labyrinth-size-5-rotations-3-seed-1283)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24  - card
+)
+(:init
+	(NOT-BLOCKED card24 W)
+	(NOT-BLOCKED card24 S)
+
+	(NOT-BLOCKED card23 W)
+	(NOT-BLOCKED card23 S)
+	(NOT-BLOCKED card23 E)
+
+	(NOT-BLOCKED card22 W)
+	(NOT-BLOCKED card22 E)
+
+	(NOT-BLOCKED card21 E)
+	(NOT-BLOCKED card21 N)
+
+	(NOT-BLOCKED card20 W)
+	(NOT-BLOCKED card20 E)
+
+	(NOT-BLOCKED card19 W)
+	(NOT-BLOCKED card19 S)
+	(NOT-BLOCKED card19 N)
+
+	(NOT-BLOCKED card18 W)
+	(NOT-BLOCKED card18 N)
+
+	(NOT-BLOCKED card17 W)
+	(NOT-BLOCKED card17 E)
+	(NOT-BLOCKED card17 N)
+
+	(NOT-BLOCKED card16 W)
+	(NOT-BLOCKED card16 S)
+	(NOT-BLOCKED card16 E)
+
+	(NOT-BLOCKED card15 S)
+	(NOT-BLOCKED card15 E)
+
+	(NOT-BLOCKED card14 W)
+	(NOT-BLOCKED card14 E)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 S)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 W)
+	(NOT-BLOCKED card12 S)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 E)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 S)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 W)
+	(NOT-BLOCKED card9 N)
+
+	(NOT-BLOCKED card8 S)
+	(NOT-BLOCKED card8 E)
+
+	(NOT-BLOCKED card7 W)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 W)
+	(NOT-BLOCKED card6 S)
+
+	(NOT-BLOCKED card5 S)
+	(NOT-BLOCKED card5 E)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 N)
+
+	(NOT-BLOCKED card3 S)
+	(NOT-BLOCKED card3 E)
+	(NOT-BLOCKED card3 N)
+
+	(NOT-BLOCKED card2 S)
+	(NOT-BLOCKED card2 E)
+
+	(NOT-BLOCKED card1 S)
+	(NOT-BLOCKED card1 N)
+
+	(NOT-BLOCKED card0 S)
+	(NOT-BLOCKED card0 N)
+
+	(MAX-POS pos4)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card22 pos2 pos0)
+	(card-at card23 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card5 pos0 pos1)
+	(card-at card6 pos1 pos1)
+	(card-at card2 pos2 pos1)
+	(card-at card3 pos3 pos1)
+	(card-at card9 pos4 pos1)
+	(card-at card14 pos0 pos2)
+	(card-at card10 pos1 pos2)
+	(card-at card11 pos2 pos2)
+	(card-at card7 pos3 pos2)
+	(card-at card8 pos4 pos2)
+	(card-at card15 pos0 pos3)
+	(card-at card16 pos1 pos3)
+	(card-at card12 pos2 pos3)
+	(card-at card13 pos3 pos3)
+	(card-at card19 pos4 pos3)
+	(card-at card20 pos0 pos4)
+	(card-at card21 pos1 pos4)
+	(card-at card17 pos2 pos4)
+	(card-at card18 pos3 pos4)
+	(card-at card24 pos4 pos4)
+
+	(BLOCKED card0 E)
+	(BLOCKED card0 W)
+
+	(BLOCKED card1 E)
+	(BLOCKED card1 W)
+
+	(BLOCKED card22 N)
+	(BLOCKED card22 S)
+
+	(BLOCKED card23 N)
+
+	(BLOCKED card4 E)
+	(BLOCKED card4 S)
+
+	(BLOCKED card5 W)
+
+	(BLOCKED card6 N)
+	(BLOCKED card6 E)
+
+	(BLOCKED card2 N)
+	(BLOCKED card2 W)
+
+	(BLOCKED card3 W)
+
+	(BLOCKED card9 E)
+	(BLOCKED card9 S)
+
+	(BLOCKED card14 N)
+	(BLOCKED card14 S)
+
+	(BLOCKED card10 E)
+	(BLOCKED card10 W)
+
+	(BLOCKED card11 S)
+	(BLOCKED card11 W)
+
+	(BLOCKED card7 E)
+	(BLOCKED card7 S)
+
+	(BLOCKED card8 N)
+	(BLOCKED card8 W)
+
+	(BLOCKED card15 N)
+	(BLOCKED card15 W)
+
+	(BLOCKED card16 N)
+
+	(BLOCKED card12 E)
+
+	(BLOCKED card13 E)
+
+	(BLOCKED card19 E)
+
+	(BLOCKED card20 N)
+	(BLOCKED card20 S)
+
+	(BLOCKED card21 S)
+	(BLOCKED card21 W)
+
+	(BLOCKED card17 S)
+
+	(BLOCKED card18 E)
+	(BLOCKED card18 S)
+
+	(BLOCKED card24 N)
+	(BLOCKED card24 E)
+
+
+	(robot-at card0)
+
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/OPT/p09.pddl
+++ b/labyrinth/OPT/p09.pddl
@@ -1,0 +1,231 @@
+;; Generated with seed: 1289, size: 5, num-rotations: 4
+(define (problem labyrinth-size-5-rotations-4-seed-1289)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24  - card
+)
+(:init
+	(NOT-BLOCKED card24 W)
+	(NOT-BLOCKED card24 S)
+	(NOT-BLOCKED card24 E)
+
+	(NOT-BLOCKED card23 E)
+	(NOT-BLOCKED card23 N)
+
+	(NOT-BLOCKED card22 W)
+	(NOT-BLOCKED card22 N)
+
+	(NOT-BLOCKED card21 S)
+	(NOT-BLOCKED card21 E)
+	(NOT-BLOCKED card21 N)
+
+	(NOT-BLOCKED card20 W)
+	(NOT-BLOCKED card20 S)
+
+	(NOT-BLOCKED card19 E)
+	(NOT-BLOCKED card19 N)
+
+	(NOT-BLOCKED card18 W)
+	(NOT-BLOCKED card18 S)
+
+	(NOT-BLOCKED card17 S)
+	(NOT-BLOCKED card17 E)
+	(NOT-BLOCKED card17 N)
+
+	(NOT-BLOCKED card16 W)
+	(NOT-BLOCKED card16 E)
+
+	(NOT-BLOCKED card15 W)
+	(NOT-BLOCKED card15 S)
+
+	(NOT-BLOCKED card14 W)
+	(NOT-BLOCKED card14 E)
+
+	(NOT-BLOCKED card13 S)
+	(NOT-BLOCKED card13 E)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 W)
+	(NOT-BLOCKED card12 S)
+
+	(NOT-BLOCKED card11 W)
+	(NOT-BLOCKED card11 S)
+	(NOT-BLOCKED card11 E)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 E)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 S)
+	(NOT-BLOCKED card9 E)
+
+	(NOT-BLOCKED card8 W)
+	(NOT-BLOCKED card8 E)
+
+	(NOT-BLOCKED card7 W)
+	(NOT-BLOCKED card7 S)
+
+	(NOT-BLOCKED card6 W)
+	(NOT-BLOCKED card6 N)
+
+	(NOT-BLOCKED card5 S)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 S)
+	(NOT-BLOCKED card4 E)
+
+	(NOT-BLOCKED card3 S)
+	(NOT-BLOCKED card3 N)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 E)
+	(NOT-BLOCKED card2 N)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 S)
+	(NOT-BLOCKED card1 E)
+
+	(NOT-BLOCKED card0 S)
+	(NOT-BLOCKED card0 N)
+
+	(MAX-POS pos4)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+
+	(card-at card0 pos0 pos0)
+	(card-at card6 pos1 pos0)
+	(card-at card11 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card5 pos0 pos1)
+	(card-at card10 pos1 pos1)
+	(card-at card17 pos2 pos1)
+	(card-at card8 pos3 pos1)
+	(card-at card9 pos4 pos1)
+	(card-at card14 pos0 pos2)
+	(card-at card16 pos1 pos2)
+	(card-at card22 pos2 pos2)
+	(card-at card12 pos3 pos2)
+	(card-at card13 pos4 pos2)
+	(card-at card15 pos0 pos3)
+	(card-at card21 pos1 pos3)
+	(card-at card2 pos2 pos3)
+	(card-at card18 pos3 pos3)
+	(card-at card19 pos4 pos3)
+	(card-at card20 pos0 pos4)
+	(card-at card1 pos1 pos4)
+	(card-at card7 pos2 pos4)
+	(card-at card23 pos3 pos4)
+	(card-at card24 pos4 pos4)
+
+	(BLOCKED card0 E)
+	(BLOCKED card0 W)
+
+	(BLOCKED card6 E)
+	(BLOCKED card6 S)
+
+
+	(BLOCKED card3 E)
+	(BLOCKED card3 W)
+
+	(BLOCKED card4 N)
+
+	(BLOCKED card5 E)
+	(BLOCKED card5 W)
+
+	(BLOCKED card10 S)
+	(BLOCKED card10 W)
+
+	(BLOCKED card17 W)
+
+	(BLOCKED card8 N)
+	(BLOCKED card8 S)
+
+	(BLOCKED card9 N)
+	(BLOCKED card9 W)
+
+	(BLOCKED card14 N)
+	(BLOCKED card14 S)
+
+	(BLOCKED card16 N)
+	(BLOCKED card16 S)
+
+	(BLOCKED card22 E)
+	(BLOCKED card22 S)
+
+	(BLOCKED card12 N)
+	(BLOCKED card12 E)
+
+	(BLOCKED card13 W)
+
+	(BLOCKED card15 N)
+	(BLOCKED card15 E)
+
+	(BLOCKED card21 W)
+
+	(BLOCKED card2 S)
+
+	(BLOCKED card18 N)
+	(BLOCKED card18 E)
+
+	(BLOCKED card19 S)
+	(BLOCKED card19 W)
+
+	(BLOCKED card20 N)
+	(BLOCKED card20 E)
+
+	(BLOCKED card1 N)
+
+	(BLOCKED card7 N)
+	(BLOCKED card7 E)
+
+	(BLOCKED card23 S)
+	(BLOCKED card23 W)
+
+	(BLOCKED card24 N)
+
+
+	(robot-at card0)
+
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/OPT/p10.pddl
+++ b/labyrinth/OPT/p10.pddl
@@ -1,0 +1,320 @@
+;; Generated with seed: 1291, size: 6, num-rotations: 1
+(define (problem labyrinth-size-6-rotations-1-seed-1291)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35  - card
+)
+(:init
+	(NOT-BLOCKED card35 W)
+	(NOT-BLOCKED card35 S)
+	(NOT-BLOCKED card35 N)
+
+	(NOT-BLOCKED card34 W)
+	(NOT-BLOCKED card34 E)
+
+	(NOT-BLOCKED card33 W)
+	(NOT-BLOCKED card33 E)
+	(NOT-BLOCKED card33 N)
+
+	(NOT-BLOCKED card32 W)
+	(NOT-BLOCKED card32 E)
+
+	(NOT-BLOCKED card31 W)
+	(NOT-BLOCKED card31 S)
+	(NOT-BLOCKED card31 E)
+
+	(NOT-BLOCKED card30 E)
+	(NOT-BLOCKED card30 N)
+
+	(NOT-BLOCKED card29 W)
+	(NOT-BLOCKED card29 S)
+
+	(NOT-BLOCKED card28 S)
+	(NOT-BLOCKED card28 E)
+
+	(NOT-BLOCKED card27 W)
+	(NOT-BLOCKED card27 E)
+
+	(NOT-BLOCKED card26 W)
+	(NOT-BLOCKED card26 S)
+
+	(NOT-BLOCKED card25 W)
+	(NOT-BLOCKED card25 S)
+	(NOT-BLOCKED card25 N)
+
+	(NOT-BLOCKED card24 S)
+	(NOT-BLOCKED card24 E)
+
+	(NOT-BLOCKED card23 W)
+	(NOT-BLOCKED card23 N)
+
+	(NOT-BLOCKED card22 W)
+	(NOT-BLOCKED card22 S)
+
+	(NOT-BLOCKED card21 E)
+	(NOT-BLOCKED card21 N)
+
+	(NOT-BLOCKED card20 W)
+	(NOT-BLOCKED card20 S)
+
+	(NOT-BLOCKED card19 S)
+	(NOT-BLOCKED card19 E)
+	(NOT-BLOCKED card19 N)
+
+	(NOT-BLOCKED card18 W)
+	(NOT-BLOCKED card18 E)
+
+	(NOT-BLOCKED card17 W)
+	(NOT-BLOCKED card17 S)
+
+	(NOT-BLOCKED card16 W)
+	(NOT-BLOCKED card16 N)
+
+	(NOT-BLOCKED card15 W)
+	(NOT-BLOCKED card15 S)
+
+	(NOT-BLOCKED card14 W)
+	(NOT-BLOCKED card14 E)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 S)
+
+	(NOT-BLOCKED card12 E)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 W)
+	(NOT-BLOCKED card11 S)
+
+	(NOT-BLOCKED card10 S)
+	(NOT-BLOCKED card10 E)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 S)
+	(NOT-BLOCKED card9 E)
+	(NOT-BLOCKED card9 N)
+
+	(NOT-BLOCKED card8 W)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 W)
+	(NOT-BLOCKED card7 S)
+
+	(NOT-BLOCKED card6 S)
+	(NOT-BLOCKED card6 E)
+	(NOT-BLOCKED card6 N)
+
+	(NOT-BLOCKED card5 W)
+	(NOT-BLOCKED card5 S)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 S)
+	(NOT-BLOCKED card4 E)
+	(NOT-BLOCKED card4 N)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 N)
+
+	(NOT-BLOCKED card2 S)
+	(NOT-BLOCKED card2 E)
+	(NOT-BLOCKED card2 N)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 N)
+
+	(NOT-BLOCKED card0 S)
+	(NOT-BLOCKED card0 E)
+
+	(MAX-POS pos5)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card5 pos5 pos0)
+	(card-at card6 pos0 pos1)
+	(card-at card7 pos1 pos1)
+	(card-at card8 pos2 pos1)
+	(card-at card9 pos3 pos1)
+	(card-at card10 pos4 pos1)
+	(card-at card11 pos5 pos1)
+	(card-at card12 pos0 pos2)
+	(card-at card13 pos1 pos2)
+	(card-at card14 pos2 pos2)
+	(card-at card15 pos3 pos2)
+	(card-at card16 pos4 pos2)
+	(card-at card17 pos5 pos2)
+	(card-at card23 pos0 pos3)
+	(card-at card18 pos1 pos3)
+	(card-at card19 pos2 pos3)
+	(card-at card20 pos3 pos3)
+	(card-at card21 pos4 pos3)
+	(card-at card22 pos5 pos3)
+	(card-at card24 pos0 pos4)
+	(card-at card25 pos1 pos4)
+	(card-at card26 pos2 pos4)
+	(card-at card27 pos3 pos4)
+	(card-at card28 pos4 pos4)
+	(card-at card29 pos5 pos4)
+	(card-at card30 pos0 pos5)
+	(card-at card31 pos1 pos5)
+	(card-at card32 pos2 pos5)
+	(card-at card33 pos3 pos5)
+	(card-at card34 pos4 pos5)
+	(card-at card35 pos5 pos5)
+
+	(BLOCKED card0 N)
+	(BLOCKED card0 W)
+
+	(BLOCKED card1 E)
+	(BLOCKED card1 S)
+
+	(BLOCKED card2 W)
+
+	(BLOCKED card3 E)
+	(BLOCKED card3 S)
+
+
+	(BLOCKED card5 E)
+
+	(BLOCKED card6 W)
+
+	(BLOCKED card7 N)
+	(BLOCKED card7 E)
+
+	(BLOCKED card8 E)
+	(BLOCKED card8 S)
+
+	(BLOCKED card9 W)
+
+	(BLOCKED card10 W)
+
+	(BLOCKED card11 N)
+	(BLOCKED card11 E)
+
+	(BLOCKED card12 S)
+	(BLOCKED card12 W)
+
+	(BLOCKED card13 N)
+	(BLOCKED card13 E)
+
+	(BLOCKED card14 N)
+	(BLOCKED card14 S)
+
+	(BLOCKED card15 N)
+	(BLOCKED card15 E)
+
+	(BLOCKED card16 E)
+	(BLOCKED card16 S)
+
+	(BLOCKED card17 N)
+	(BLOCKED card17 E)
+
+	(BLOCKED card23 E)
+	(BLOCKED card23 S)
+
+	(BLOCKED card18 N)
+	(BLOCKED card18 S)
+
+	(BLOCKED card19 W)
+
+	(BLOCKED card20 N)
+	(BLOCKED card20 E)
+
+	(BLOCKED card21 S)
+	(BLOCKED card21 W)
+
+	(BLOCKED card22 N)
+	(BLOCKED card22 E)
+
+	(BLOCKED card24 N)
+	(BLOCKED card24 W)
+
+	(BLOCKED card25 E)
+
+	(BLOCKED card26 N)
+	(BLOCKED card26 E)
+
+	(BLOCKED card27 N)
+	(BLOCKED card27 S)
+
+	(BLOCKED card28 N)
+	(BLOCKED card28 W)
+
+	(BLOCKED card29 N)
+	(BLOCKED card29 E)
+
+	(BLOCKED card30 S)
+	(BLOCKED card30 W)
+
+	(BLOCKED card31 N)
+
+	(BLOCKED card32 N)
+	(BLOCKED card32 S)
+
+	(BLOCKED card33 S)
+
+	(BLOCKED card34 N)
+	(BLOCKED card34 S)
+
+	(BLOCKED card35 E)
+
+
+	(robot-at card0)
+
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/OPT/p11.pddl
+++ b/labyrinth/OPT/p11.pddl
@@ -1,0 +1,320 @@
+;; Generated with seed: 1297, size: 6, num-rotations: 2
+(define (problem labyrinth-size-6-rotations-2-seed-1297)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35  - card
+)
+(:init
+	(NOT-BLOCKED card35 S)
+	(NOT-BLOCKED card35 N)
+
+	(NOT-BLOCKED card34 W)
+	(NOT-BLOCKED card34 S)
+	(NOT-BLOCKED card34 E)
+
+	(NOT-BLOCKED card33 E)
+	(NOT-BLOCKED card33 N)
+
+	(NOT-BLOCKED card32 S)
+	(NOT-BLOCKED card32 E)
+
+	(NOT-BLOCKED card31 W)
+	(NOT-BLOCKED card31 S)
+
+	(NOT-BLOCKED card30 S)
+	(NOT-BLOCKED card30 N)
+
+	(NOT-BLOCKED card29 W)
+	(NOT-BLOCKED card29 S)
+
+	(NOT-BLOCKED card28 E)
+	(NOT-BLOCKED card28 N)
+
+	(NOT-BLOCKED card27 W)
+	(NOT-BLOCKED card27 N)
+
+	(NOT-BLOCKED card26 W)
+	(NOT-BLOCKED card26 E)
+
+	(NOT-BLOCKED card25 W)
+	(NOT-BLOCKED card25 N)
+
+	(NOT-BLOCKED card24 S)
+	(NOT-BLOCKED card24 E)
+
+	(NOT-BLOCKED card23 S)
+	(NOT-BLOCKED card23 N)
+
+	(NOT-BLOCKED card22 S)
+	(NOT-BLOCKED card22 N)
+
+	(NOT-BLOCKED card21 W)
+	(NOT-BLOCKED card21 N)
+
+	(NOT-BLOCKED card20 W)
+	(NOT-BLOCKED card20 E)
+	(NOT-BLOCKED card20 N)
+
+	(NOT-BLOCKED card19 E)
+	(NOT-BLOCKED card19 N)
+
+	(NOT-BLOCKED card18 W)
+	(NOT-BLOCKED card18 S)
+	(NOT-BLOCKED card18 N)
+
+	(NOT-BLOCKED card17 W)
+	(NOT-BLOCKED card17 E)
+	(NOT-BLOCKED card17 N)
+
+	(NOT-BLOCKED card16 W)
+	(NOT-BLOCKED card16 S)
+
+	(NOT-BLOCKED card15 W)
+	(NOT-BLOCKED card15 E)
+
+	(NOT-BLOCKED card14 S)
+	(NOT-BLOCKED card14 E)
+	(NOT-BLOCKED card14 N)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 S)
+	(NOT-BLOCKED card13 E)
+
+	(NOT-BLOCKED card12 W)
+	(NOT-BLOCKED card12 E)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 S)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 S)
+	(NOT-BLOCKED card10 E)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 S)
+	(NOT-BLOCKED card9 E)
+
+	(NOT-BLOCKED card8 W)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 E)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 S)
+	(NOT-BLOCKED card6 N)
+
+	(NOT-BLOCKED card5 S)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 S)
+	(NOT-BLOCKED card4 E)
+
+	(NOT-BLOCKED card3 S)
+	(NOT-BLOCKED card3 E)
+
+	(NOT-BLOCKED card2 E)
+	(NOT-BLOCKED card2 N)
+
+	(NOT-BLOCKED card1 E)
+	(NOT-BLOCKED card1 N)
+
+	(NOT-BLOCKED card0 S)
+	(NOT-BLOCKED card0 E)
+
+	(MAX-POS pos5)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card32 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card5 pos5 pos0)
+	(card-at card6 pos0 pos1)
+	(card-at card7 pos1 pos1)
+	(card-at card2 pos2 pos1)
+	(card-at card9 pos3 pos1)
+	(card-at card10 pos4 pos1)
+	(card-at card11 pos5 pos1)
+	(card-at card12 pos0 pos2)
+	(card-at card13 pos1 pos2)
+	(card-at card8 pos2 pos2)
+	(card-at card15 pos3 pos2)
+	(card-at card16 pos4 pos2)
+	(card-at card17 pos5 pos2)
+	(card-at card18 pos0 pos3)
+	(card-at card19 pos1 pos3)
+	(card-at card14 pos2 pos3)
+	(card-at card21 pos3 pos3)
+	(card-at card22 pos4 pos3)
+	(card-at card23 pos5 pos3)
+	(card-at card29 pos0 pos4)
+	(card-at card24 pos1 pos4)
+	(card-at card20 pos2 pos4)
+	(card-at card26 pos3 pos4)
+	(card-at card27 pos4 pos4)
+	(card-at card28 pos5 pos4)
+	(card-at card30 pos0 pos5)
+	(card-at card31 pos1 pos5)
+	(card-at card25 pos2 pos5)
+	(card-at card33 pos3 pos5)
+	(card-at card34 pos4 pos5)
+	(card-at card35 pos5 pos5)
+
+	(BLOCKED card0 N)
+	(BLOCKED card0 W)
+
+	(BLOCKED card1 S)
+	(BLOCKED card1 W)
+
+	(BLOCKED card32 N)
+	(BLOCKED card32 W)
+
+	(BLOCKED card3 N)
+	(BLOCKED card3 W)
+
+	(BLOCKED card4 N)
+	(BLOCKED card4 W)
+
+	(BLOCKED card5 E)
+	(BLOCKED card5 W)
+
+	(BLOCKED card6 E)
+	(BLOCKED card6 W)
+
+	(BLOCKED card7 S)
+	(BLOCKED card7 W)
+
+	(BLOCKED card2 S)
+	(BLOCKED card2 W)
+
+	(BLOCKED card9 N)
+	(BLOCKED card9 W)
+
+	(BLOCKED card10 W)
+
+	(BLOCKED card11 E)
+	(BLOCKED card11 W)
+
+	(BLOCKED card12 S)
+
+	(BLOCKED card13 N)
+
+	(BLOCKED card8 E)
+	(BLOCKED card8 S)
+
+	(BLOCKED card15 N)
+	(BLOCKED card15 S)
+
+	(BLOCKED card16 N)
+	(BLOCKED card16 E)
+
+	(BLOCKED card17 S)
+
+	(BLOCKED card18 E)
+
+	(BLOCKED card19 S)
+	(BLOCKED card19 W)
+
+	(BLOCKED card14 W)
+
+	(BLOCKED card21 E)
+	(BLOCKED card21 S)
+
+	(BLOCKED card22 E)
+	(BLOCKED card22 W)
+
+	(BLOCKED card23 E)
+	(BLOCKED card23 W)
+
+	(BLOCKED card29 N)
+	(BLOCKED card29 E)
+
+	(BLOCKED card24 N)
+	(BLOCKED card24 W)
+
+	(BLOCKED card20 S)
+
+	(BLOCKED card26 N)
+	(BLOCKED card26 S)
+
+	(BLOCKED card27 E)
+	(BLOCKED card27 S)
+
+	(BLOCKED card28 S)
+	(BLOCKED card28 W)
+
+	(BLOCKED card30 E)
+	(BLOCKED card30 W)
+
+	(BLOCKED card31 N)
+	(BLOCKED card31 E)
+
+	(BLOCKED card25 E)
+	(BLOCKED card25 S)
+
+	(BLOCKED card33 S)
+	(BLOCKED card33 W)
+
+	(BLOCKED card34 N)
+
+	(BLOCKED card35 E)
+	(BLOCKED card35 W)
+
+
+	(robot-at card0)
+
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/OPT/p12.pddl
+++ b/labyrinth/OPT/p12.pddl
@@ -1,0 +1,320 @@
+;; Generated with seed: 1301, size: 6, num-rotations: 3
+(define (problem labyrinth-size-6-rotations-3-seed-1301)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35  - card
+)
+(:init
+	(NOT-BLOCKED card35 S)
+	(NOT-BLOCKED card35 N)
+
+	(NOT-BLOCKED card34 W)
+	(NOT-BLOCKED card34 N)
+
+	(NOT-BLOCKED card33 W)
+	(NOT-BLOCKED card33 E)
+	(NOT-BLOCKED card33 N)
+
+	(NOT-BLOCKED card32 W)
+	(NOT-BLOCKED card32 N)
+
+	(NOT-BLOCKED card31 W)
+	(NOT-BLOCKED card31 N)
+
+	(NOT-BLOCKED card30 W)
+	(NOT-BLOCKED card30 N)
+
+	(NOT-BLOCKED card29 W)
+	(NOT-BLOCKED card29 S)
+	(NOT-BLOCKED card29 N)
+
+	(NOT-BLOCKED card28 W)
+	(NOT-BLOCKED card28 S)
+	(NOT-BLOCKED card28 E)
+
+	(NOT-BLOCKED card27 W)
+	(NOT-BLOCKED card27 S)
+	(NOT-BLOCKED card27 N)
+
+	(NOT-BLOCKED card26 W)
+	(NOT-BLOCKED card26 E)
+	(NOT-BLOCKED card26 N)
+
+	(NOT-BLOCKED card25 S)
+	(NOT-BLOCKED card25 N)
+
+	(NOT-BLOCKED card24 W)
+	(NOT-BLOCKED card24 S)
+
+	(NOT-BLOCKED card23 W)
+	(NOT-BLOCKED card23 S)
+	(NOT-BLOCKED card23 N)
+
+	(NOT-BLOCKED card22 W)
+	(NOT-BLOCKED card22 E)
+
+	(NOT-BLOCKED card21 W)
+	(NOT-BLOCKED card21 S)
+	(NOT-BLOCKED card21 E)
+
+	(NOT-BLOCKED card20 S)
+	(NOT-BLOCKED card20 E)
+	(NOT-BLOCKED card20 N)
+
+	(NOT-BLOCKED card19 W)
+	(NOT-BLOCKED card19 N)
+
+	(NOT-BLOCKED card18 W)
+	(NOT-BLOCKED card18 E)
+	(NOT-BLOCKED card18 N)
+
+	(NOT-BLOCKED card17 S)
+	(NOT-BLOCKED card17 N)
+
+	(NOT-BLOCKED card16 W)
+	(NOT-BLOCKED card16 S)
+
+	(NOT-BLOCKED card15 W)
+	(NOT-BLOCKED card15 S)
+
+	(NOT-BLOCKED card14 W)
+	(NOT-BLOCKED card14 S)
+	(NOT-BLOCKED card14 E)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 E)
+
+	(NOT-BLOCKED card12 E)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 S)
+	(NOT-BLOCKED card11 E)
+
+	(NOT-BLOCKED card10 W)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 W)
+	(NOT-BLOCKED card9 S)
+
+	(NOT-BLOCKED card8 S)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 W)
+	(NOT-BLOCKED card7 E)
+
+	(NOT-BLOCKED card6 S)
+	(NOT-BLOCKED card6 N)
+
+	(NOT-BLOCKED card5 S)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 S)
+
+	(NOT-BLOCKED card3 E)
+	(NOT-BLOCKED card3 N)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 S)
+	(NOT-BLOCKED card2 N)
+
+	(NOT-BLOCKED card1 S)
+	(NOT-BLOCKED card1 N)
+
+	(NOT-BLOCKED card0 S)
+	(NOT-BLOCKED card0 N)
+
+	(MAX-POS pos5)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card16 pos4 pos0)
+	(card-at card5 pos5 pos0)
+	(card-at card6 pos0 pos1)
+	(card-at card7 pos1 pos1)
+	(card-at card8 pos2 pos1)
+	(card-at card9 pos3 pos1)
+	(card-at card22 pos4 pos1)
+	(card-at card11 pos5 pos1)
+	(card-at card12 pos0 pos2)
+	(card-at card13 pos1 pos2)
+	(card-at card14 pos2 pos2)
+	(card-at card15 pos3 pos2)
+	(card-at card29 pos4 pos2)
+	(card-at card17 pos5 pos2)
+	(card-at card18 pos0 pos3)
+	(card-at card19 pos1 pos3)
+	(card-at card20 pos2 pos3)
+	(card-at card21 pos3 pos3)
+	(card-at card34 pos4 pos3)
+	(card-at card23 pos5 pos3)
+	(card-at card25 pos0 pos4)
+	(card-at card26 pos1 pos4)
+	(card-at card27 pos2 pos4)
+	(card-at card28 pos3 pos4)
+	(card-at card4 pos4 pos4)
+	(card-at card24 pos5 pos4)
+	(card-at card30 pos0 pos5)
+	(card-at card31 pos1 pos5)
+	(card-at card32 pos2 pos5)
+	(card-at card33 pos3 pos5)
+	(card-at card10 pos4 pos5)
+	(card-at card35 pos5 pos5)
+
+	(BLOCKED card0 E)
+	(BLOCKED card0 W)
+
+	(BLOCKED card1 E)
+	(BLOCKED card1 W)
+
+	(BLOCKED card2 E)
+
+	(BLOCKED card3 S)
+	(BLOCKED card3 W)
+
+	(BLOCKED card16 N)
+	(BLOCKED card16 E)
+
+	(BLOCKED card5 E)
+	(BLOCKED card5 W)
+
+	(BLOCKED card6 E)
+	(BLOCKED card6 W)
+
+	(BLOCKED card7 N)
+	(BLOCKED card7 S)
+
+	(BLOCKED card8 E)
+	(BLOCKED card8 W)
+
+	(BLOCKED card9 N)
+	(BLOCKED card9 E)
+
+	(BLOCKED card22 N)
+	(BLOCKED card22 S)
+
+	(BLOCKED card11 N)
+	(BLOCKED card11 W)
+
+	(BLOCKED card12 S)
+	(BLOCKED card12 W)
+
+	(BLOCKED card13 N)
+	(BLOCKED card13 S)
+
+	(BLOCKED card14 N)
+
+	(BLOCKED card15 N)
+	(BLOCKED card15 E)
+
+	(BLOCKED card29 E)
+
+	(BLOCKED card17 E)
+	(BLOCKED card17 W)
+
+	(BLOCKED card18 S)
+
+	(BLOCKED card19 E)
+	(BLOCKED card19 S)
+
+	(BLOCKED card20 W)
+
+	(BLOCKED card21 N)
+
+	(BLOCKED card34 E)
+	(BLOCKED card34 S)
+
+	(BLOCKED card23 E)
+
+	(BLOCKED card25 E)
+	(BLOCKED card25 W)
+
+	(BLOCKED card26 S)
+
+	(BLOCKED card27 E)
+
+	(BLOCKED card28 N)
+
+	(BLOCKED card4 N)
+	(BLOCKED card4 E)
+
+	(BLOCKED card24 N)
+	(BLOCKED card24 E)
+
+	(BLOCKED card30 E)
+	(BLOCKED card30 S)
+
+	(BLOCKED card31 E)
+	(BLOCKED card31 S)
+
+	(BLOCKED card32 E)
+	(BLOCKED card32 S)
+
+	(BLOCKED card33 S)
+
+	(BLOCKED card10 E)
+	(BLOCKED card10 S)
+
+	(BLOCKED card35 E)
+	(BLOCKED card35 W)
+
+
+	(robot-at card0)
+
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/OPT/p13.pddl
+++ b/labyrinth/OPT/p13.pddl
@@ -1,0 +1,320 @@
+;; Generated with seed: 1303, size: 6, num-rotations: 4
+(define (problem labyrinth-size-6-rotations-4-seed-1303)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35  - card
+)
+(:init
+	(NOT-BLOCKED card35 W)
+	(NOT-BLOCKED card35 S)
+	(NOT-BLOCKED card35 E)
+
+	(NOT-BLOCKED card34 W)
+	(NOT-BLOCKED card34 S)
+	(NOT-BLOCKED card34 E)
+
+	(NOT-BLOCKED card33 S)
+	(NOT-BLOCKED card33 E)
+	(NOT-BLOCKED card33 N)
+
+	(NOT-BLOCKED card32 S)
+	(NOT-BLOCKED card32 N)
+
+	(NOT-BLOCKED card31 W)
+	(NOT-BLOCKED card31 N)
+
+	(NOT-BLOCKED card30 E)
+	(NOT-BLOCKED card30 N)
+
+	(NOT-BLOCKED card29 E)
+	(NOT-BLOCKED card29 N)
+
+	(NOT-BLOCKED card28 E)
+	(NOT-BLOCKED card28 N)
+
+	(NOT-BLOCKED card27 W)
+	(NOT-BLOCKED card27 S)
+	(NOT-BLOCKED card27 E)
+
+	(NOT-BLOCKED card26 W)
+	(NOT-BLOCKED card26 E)
+	(NOT-BLOCKED card26 N)
+
+	(NOT-BLOCKED card25 W)
+	(NOT-BLOCKED card25 S)
+	(NOT-BLOCKED card25 E)
+
+	(NOT-BLOCKED card24 W)
+	(NOT-BLOCKED card24 E)
+	(NOT-BLOCKED card24 N)
+
+	(NOT-BLOCKED card23 S)
+	(NOT-BLOCKED card23 E)
+
+	(NOT-BLOCKED card22 W)
+	(NOT-BLOCKED card22 S)
+	(NOT-BLOCKED card22 E)
+	(NOT-BLOCKED card22 N)
+
+	(NOT-BLOCKED card21 W)
+	(NOT-BLOCKED card21 S)
+
+	(NOT-BLOCKED card20 S)
+	(NOT-BLOCKED card20 E)
+
+	(NOT-BLOCKED card19 W)
+	(NOT-BLOCKED card19 E)
+	(NOT-BLOCKED card19 N)
+
+	(NOT-BLOCKED card18 S)
+	(NOT-BLOCKED card18 N)
+
+	(NOT-BLOCKED card17 W)
+	(NOT-BLOCKED card17 N)
+
+	(NOT-BLOCKED card16 W)
+	(NOT-BLOCKED card16 S)
+	(NOT-BLOCKED card16 N)
+
+	(NOT-BLOCKED card15 E)
+	(NOT-BLOCKED card15 N)
+
+	(NOT-BLOCKED card14 S)
+	(NOT-BLOCKED card14 E)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 S)
+	(NOT-BLOCKED card12 E)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 E)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 E)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 E)
+	(NOT-BLOCKED card9 N)
+
+	(NOT-BLOCKED card8 W)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 E)
+
+	(NOT-BLOCKED card6 W)
+	(NOT-BLOCKED card6 S)
+	(NOT-BLOCKED card6 N)
+
+	(NOT-BLOCKED card5 W)
+	(NOT-BLOCKED card5 S)
+	(NOT-BLOCKED card5 E)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 E)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 N)
+
+	(NOT-BLOCKED card2 E)
+	(NOT-BLOCKED card2 N)
+
+	(NOT-BLOCKED card1 E)
+	(NOT-BLOCKED card1 N)
+
+	(NOT-BLOCKED card0 W)
+	(NOT-BLOCKED card0 S)
+	(NOT-BLOCKED card0 E)
+	(NOT-BLOCKED card0 N)
+
+	(MAX-POS pos5)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card8 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card5 pos5 pos0)
+	(card-at card6 pos0 pos1)
+	(card-at card7 pos1 pos1)
+	(card-at card14 pos2 pos1)
+	(card-at card9 pos3 pos1)
+	(card-at card10 pos4 pos1)
+	(card-at card11 pos5 pos1)
+	(card-at card12 pos0 pos2)
+	(card-at card13 pos1 pos2)
+	(card-at card21 pos2 pos2)
+	(card-at card15 pos3 pos2)
+	(card-at card16 pos4 pos2)
+	(card-at card17 pos5 pos2)
+	(card-at card20 pos0 pos3)
+	(card-at card26 pos1 pos3)
+	(card-at card22 pos2 pos3)
+	(card-at card23 pos3 pos3)
+	(card-at card18 pos4 pos3)
+	(card-at card19 pos5 pos3)
+	(card-at card29 pos0 pos4)
+	(card-at card24 pos1 pos4)
+	(card-at card25 pos2 pos4)
+	(card-at card32 pos3 pos4)
+	(card-at card27 pos4 pos4)
+	(card-at card28 pos5 pos4)
+	(card-at card30 pos0 pos5)
+	(card-at card31 pos1 pos5)
+	(card-at card2 pos2 pos5)
+	(card-at card33 pos3 pos5)
+	(card-at card34 pos4 pos5)
+	(card-at card35 pos5 pos5)
+
+
+	(BLOCKED card1 S)
+	(BLOCKED card1 W)
+
+	(BLOCKED card8 E)
+	(BLOCKED card8 S)
+
+	(BLOCKED card3 E)
+	(BLOCKED card3 S)
+
+	(BLOCKED card4 N)
+	(BLOCKED card4 S)
+
+	(BLOCKED card5 N)
+
+	(BLOCKED card6 E)
+
+	(BLOCKED card7 N)
+	(BLOCKED card7 W)
+
+	(BLOCKED card14 N)
+	(BLOCKED card14 W)
+
+	(BLOCKED card9 S)
+	(BLOCKED card9 W)
+
+	(BLOCKED card10 S)
+	(BLOCKED card10 W)
+
+	(BLOCKED card11 S)
+	(BLOCKED card11 W)
+
+	(BLOCKED card12 W)
+
+	(BLOCKED card13 E)
+	(BLOCKED card13 S)
+
+	(BLOCKED card21 N)
+	(BLOCKED card21 E)
+
+	(BLOCKED card15 S)
+	(BLOCKED card15 W)
+
+	(BLOCKED card16 E)
+
+	(BLOCKED card17 E)
+	(BLOCKED card17 S)
+
+	(BLOCKED card20 N)
+	(BLOCKED card20 W)
+
+	(BLOCKED card26 S)
+
+
+	(BLOCKED card23 N)
+	(BLOCKED card23 W)
+
+	(BLOCKED card18 E)
+	(BLOCKED card18 W)
+
+	(BLOCKED card19 S)
+
+	(BLOCKED card29 S)
+	(BLOCKED card29 W)
+
+	(BLOCKED card24 S)
+
+	(BLOCKED card25 N)
+
+	(BLOCKED card32 E)
+	(BLOCKED card32 W)
+
+	(BLOCKED card27 N)
+
+	(BLOCKED card28 S)
+	(BLOCKED card28 W)
+
+	(BLOCKED card30 S)
+	(BLOCKED card30 W)
+
+	(BLOCKED card31 E)
+	(BLOCKED card31 S)
+
+	(BLOCKED card2 S)
+	(BLOCKED card2 W)
+
+	(BLOCKED card33 W)
+
+	(BLOCKED card34 N)
+
+	(BLOCKED card35 N)
+
+
+	(robot-at card0)
+
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/OPT/p14.pddl
+++ b/labyrinth/OPT/p14.pddl
@@ -1,0 +1,320 @@
+;; Generated with seed: 1307, size: 6, num-rotations: 6
+(define (problem labyrinth-size-6-rotations-6-seed-1307)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35  - card
+)
+(:init
+	(NOT-BLOCKED card35 S)
+	(NOT-BLOCKED card35 N)
+
+	(NOT-BLOCKED card34 W)
+	(NOT-BLOCKED card34 S)
+
+	(NOT-BLOCKED card33 W)
+	(NOT-BLOCKED card33 S)
+	(NOT-BLOCKED card33 E)
+
+	(NOT-BLOCKED card32 W)
+	(NOT-BLOCKED card32 S)
+
+	(NOT-BLOCKED card31 W)
+	(NOT-BLOCKED card31 E)
+
+	(NOT-BLOCKED card30 S)
+	(NOT-BLOCKED card30 N)
+
+	(NOT-BLOCKED card29 S)
+	(NOT-BLOCKED card29 N)
+
+	(NOT-BLOCKED card28 S)
+	(NOT-BLOCKED card28 E)
+
+	(NOT-BLOCKED card27 W)
+	(NOT-BLOCKED card27 S)
+	(NOT-BLOCKED card27 E)
+
+	(NOT-BLOCKED card26 W)
+	(NOT-BLOCKED card26 E)
+
+	(NOT-BLOCKED card25 S)
+	(NOT-BLOCKED card25 E)
+	(NOT-BLOCKED card25 N)
+
+	(NOT-BLOCKED card24 W)
+	(NOT-BLOCKED card24 N)
+
+	(NOT-BLOCKED card23 S)
+	(NOT-BLOCKED card23 E)
+	(NOT-BLOCKED card23 N)
+
+	(NOT-BLOCKED card22 W)
+	(NOT-BLOCKED card22 E)
+
+	(NOT-BLOCKED card21 E)
+	(NOT-BLOCKED card21 N)
+
+	(NOT-BLOCKED card20 S)
+	(NOT-BLOCKED card20 N)
+
+	(NOT-BLOCKED card19 S)
+	(NOT-BLOCKED card19 N)
+
+	(NOT-BLOCKED card18 W)
+	(NOT-BLOCKED card18 N)
+
+	(NOT-BLOCKED card17 S)
+	(NOT-BLOCKED card17 N)
+
+	(NOT-BLOCKED card16 W)
+	(NOT-BLOCKED card16 N)
+
+	(NOT-BLOCKED card15 W)
+	(NOT-BLOCKED card15 E)
+
+	(NOT-BLOCKED card14 S)
+	(NOT-BLOCKED card14 N)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 W)
+	(NOT-BLOCKED card12 E)
+
+	(NOT-BLOCKED card11 S)
+	(NOT-BLOCKED card11 E)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 S)
+	(NOT-BLOCKED card10 E)
+
+	(NOT-BLOCKED card9 E)
+	(NOT-BLOCKED card9 N)
+
+	(NOT-BLOCKED card8 E)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 W)
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 S)
+	(NOT-BLOCKED card6 E)
+	(NOT-BLOCKED card6 N)
+
+	(NOT-BLOCKED card5 W)
+	(NOT-BLOCKED card5 S)
+	(NOT-BLOCKED card5 E)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 S)
+	(NOT-BLOCKED card4 E)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 S)
+	(NOT-BLOCKED card3 E)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 E)
+
+	(NOT-BLOCKED card1 S)
+	(NOT-BLOCKED card1 E)
+	(NOT-BLOCKED card1 N)
+
+	(NOT-BLOCKED card0 S)
+	(NOT-BLOCKED card0 E)
+
+	(MAX-POS pos5)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card34 pos4 pos0)
+	(card-at card5 pos5 pos0)
+	(card-at card11 pos0 pos1)
+	(card-at card6 pos1 pos1)
+	(card-at card7 pos2 pos1)
+	(card-at card8 pos3 pos1)
+	(card-at card4 pos4 pos1)
+	(card-at card10 pos5 pos1)
+	(card-at card12 pos0 pos2)
+	(card-at card13 pos1 pos2)
+	(card-at card14 pos2 pos2)
+	(card-at card9 pos3 pos2)
+	(card-at card16 pos4 pos2)
+	(card-at card17 pos5 pos2)
+	(card-at card18 pos0 pos3)
+	(card-at card19 pos1 pos3)
+	(card-at card20 pos2 pos3)
+	(card-at card21 pos3 pos3)
+	(card-at card15 pos4 pos3)
+	(card-at card23 pos5 pos3)
+	(card-at card24 pos0 pos4)
+	(card-at card25 pos1 pos4)
+	(card-at card26 pos2 pos4)
+	(card-at card27 pos3 pos4)
+	(card-at card22 pos4 pos4)
+	(card-at card29 pos5 pos4)
+	(card-at card30 pos0 pos5)
+	(card-at card31 pos1 pos5)
+	(card-at card32 pos2 pos5)
+	(card-at card33 pos3 pos5)
+	(card-at card28 pos4 pos5)
+	(card-at card35 pos5 pos5)
+
+	(BLOCKED card0 N)
+	(BLOCKED card0 W)
+
+	(BLOCKED card1 W)
+
+	(BLOCKED card2 N)
+	(BLOCKED card2 S)
+
+	(BLOCKED card3 N)
+
+	(BLOCKED card34 N)
+	(BLOCKED card34 E)
+
+	(BLOCKED card5 N)
+
+	(BLOCKED card11 W)
+
+	(BLOCKED card6 W)
+
+	(BLOCKED card7 E)
+
+	(BLOCKED card8 S)
+	(BLOCKED card8 W)
+
+	(BLOCKED card4 N)
+
+	(BLOCKED card10 N)
+	(BLOCKED card10 W)
+
+	(BLOCKED card12 N)
+	(BLOCKED card12 S)
+
+	(BLOCKED card13 E)
+	(BLOCKED card13 S)
+
+	(BLOCKED card14 E)
+	(BLOCKED card14 W)
+
+	(BLOCKED card9 S)
+	(BLOCKED card9 W)
+
+	(BLOCKED card16 E)
+	(BLOCKED card16 S)
+
+	(BLOCKED card17 E)
+	(BLOCKED card17 W)
+
+	(BLOCKED card18 E)
+	(BLOCKED card18 S)
+
+	(BLOCKED card19 E)
+	(BLOCKED card19 W)
+
+	(BLOCKED card20 E)
+	(BLOCKED card20 W)
+
+	(BLOCKED card21 S)
+	(BLOCKED card21 W)
+
+	(BLOCKED card15 N)
+	(BLOCKED card15 S)
+
+	(BLOCKED card23 W)
+
+	(BLOCKED card24 E)
+	(BLOCKED card24 S)
+
+	(BLOCKED card25 W)
+
+	(BLOCKED card26 N)
+	(BLOCKED card26 S)
+
+	(BLOCKED card27 N)
+
+	(BLOCKED card22 N)
+	(BLOCKED card22 S)
+
+	(BLOCKED card29 E)
+	(BLOCKED card29 W)
+
+	(BLOCKED card30 E)
+	(BLOCKED card30 W)
+
+	(BLOCKED card31 N)
+	(BLOCKED card31 S)
+
+	(BLOCKED card32 N)
+	(BLOCKED card32 E)
+
+	(BLOCKED card33 N)
+
+	(BLOCKED card28 N)
+	(BLOCKED card28 W)
+
+	(BLOCKED card35 E)
+	(BLOCKED card35 W)
+
+
+	(robot-at card0)
+
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/OPT/p15.pddl
+++ b/labyrinth/OPT/p15.pddl
@@ -1,0 +1,425 @@
+;; Generated with seed: 1319, size: 7, num-rotations: 1
+(define (problem labyrinth-size-7-rotations-1-seed-1319)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5 pos6  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35 card36 card37 card38 card39 card40 card41 card42 card43 card44 card45 card46 card47 card48  - card
+)
+(:init
+	(NOT-BLOCKED card48 W)
+	(NOT-BLOCKED card48 S)
+	(NOT-BLOCKED card48 E)
+
+	(NOT-BLOCKED card47 E)
+	(NOT-BLOCKED card47 N)
+
+	(NOT-BLOCKED card46 S)
+	(NOT-BLOCKED card46 E)
+
+	(NOT-BLOCKED card45 W)
+	(NOT-BLOCKED card45 E)
+
+	(NOT-BLOCKED card44 S)
+	(NOT-BLOCKED card44 E)
+	(NOT-BLOCKED card44 N)
+
+	(NOT-BLOCKED card43 S)
+	(NOT-BLOCKED card43 N)
+
+	(NOT-BLOCKED card42 E)
+	(NOT-BLOCKED card42 N)
+
+	(NOT-BLOCKED card41 E)
+	(NOT-BLOCKED card41 N)
+
+	(NOT-BLOCKED card40 W)
+	(NOT-BLOCKED card40 S)
+	(NOT-BLOCKED card40 N)
+
+	(NOT-BLOCKED card39 E)
+	(NOT-BLOCKED card39 N)
+
+	(NOT-BLOCKED card38 W)
+	(NOT-BLOCKED card38 N)
+
+	(NOT-BLOCKED card37 E)
+	(NOT-BLOCKED card37 N)
+
+	(NOT-BLOCKED card36 W)
+	(NOT-BLOCKED card36 S)
+
+	(NOT-BLOCKED card35 W)
+	(NOT-BLOCKED card35 N)
+
+	(NOT-BLOCKED card34 W)
+	(NOT-BLOCKED card34 S)
+	(NOT-BLOCKED card34 E)
+	(NOT-BLOCKED card34 N)
+
+	(NOT-BLOCKED card33 E)
+	(NOT-BLOCKED card33 N)
+
+	(NOT-BLOCKED card32 W)
+	(NOT-BLOCKED card32 S)
+
+	(NOT-BLOCKED card31 S)
+	(NOT-BLOCKED card31 E)
+
+	(NOT-BLOCKED card30 W)
+	(NOT-BLOCKED card30 S)
+	(NOT-BLOCKED card30 N)
+
+	(NOT-BLOCKED card29 W)
+	(NOT-BLOCKED card29 E)
+
+	(NOT-BLOCKED card28 W)
+	(NOT-BLOCKED card28 E)
+	(NOT-BLOCKED card28 N)
+
+	(NOT-BLOCKED card27 S)
+	(NOT-BLOCKED card27 N)
+
+	(NOT-BLOCKED card26 W)
+	(NOT-BLOCKED card26 S)
+	(NOT-BLOCKED card26 N)
+
+	(NOT-BLOCKED card25 S)
+	(NOT-BLOCKED card25 N)
+
+	(NOT-BLOCKED card24 W)
+	(NOT-BLOCKED card24 E)
+
+	(NOT-BLOCKED card23 E)
+	(NOT-BLOCKED card23 N)
+
+	(NOT-BLOCKED card22 S)
+	(NOT-BLOCKED card22 N)
+
+	(NOT-BLOCKED card21 S)
+	(NOT-BLOCKED card21 N)
+
+	(NOT-BLOCKED card20 W)
+	(NOT-BLOCKED card20 S)
+
+	(NOT-BLOCKED card19 S)
+	(NOT-BLOCKED card19 E)
+
+	(NOT-BLOCKED card18 S)
+	(NOT-BLOCKED card18 N)
+
+	(NOT-BLOCKED card17 W)
+	(NOT-BLOCKED card17 E)
+
+	(NOT-BLOCKED card16 E)
+	(NOT-BLOCKED card16 N)
+
+	(NOT-BLOCKED card15 S)
+	(NOT-BLOCKED card15 E)
+
+	(NOT-BLOCKED card14 S)
+	(NOT-BLOCKED card14 E)
+	(NOT-BLOCKED card14 N)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 S)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 S)
+	(NOT-BLOCKED card12 E)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 E)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 E)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 W)
+	(NOT-BLOCKED card9 S)
+	(NOT-BLOCKED card9 E)
+
+	(NOT-BLOCKED card8 W)
+	(NOT-BLOCKED card8 E)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 W)
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 E)
+
+	(NOT-BLOCKED card6 W)
+	(NOT-BLOCKED card6 N)
+
+	(NOT-BLOCKED card5 W)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 E)
+
+	(NOT-BLOCKED card3 S)
+	(NOT-BLOCKED card3 N)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 S)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 S)
+
+	(NOT-BLOCKED card0 S)
+	(NOT-BLOCKED card0 E)
+
+	(MAX-POS pos6)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+	(NEXT pos6 pos5)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card5 pos5 pos0)
+	(card-at card6 pos6 pos0)
+	(card-at card7 pos0 pos1)
+	(card-at card8 pos1 pos1)
+	(card-at card9 pos2 pos1)
+	(card-at card10 pos3 pos1)
+	(card-at card11 pos4 pos1)
+	(card-at card12 pos5 pos1)
+	(card-at card13 pos6 pos1)
+	(card-at card14 pos0 pos2)
+	(card-at card15 pos1 pos2)
+	(card-at card16 pos2 pos2)
+	(card-at card17 pos3 pos2)
+	(card-at card18 pos4 pos2)
+	(card-at card19 pos5 pos2)
+	(card-at card20 pos6 pos2)
+	(card-at card21 pos0 pos3)
+	(card-at card22 pos1 pos3)
+	(card-at card23 pos2 pos3)
+	(card-at card24 pos3 pos3)
+	(card-at card25 pos4 pos3)
+	(card-at card26 pos5 pos3)
+	(card-at card27 pos6 pos3)
+	(card-at card29 pos0 pos4)
+	(card-at card30 pos1 pos4)
+	(card-at card31 pos2 pos4)
+	(card-at card32 pos3 pos4)
+	(card-at card33 pos4 pos4)
+	(card-at card34 pos5 pos4)
+	(card-at card28 pos6 pos4)
+	(card-at card35 pos0 pos5)
+	(card-at card36 pos1 pos5)
+	(card-at card37 pos2 pos5)
+	(card-at card38 pos3 pos5)
+	(card-at card39 pos4 pos5)
+	(card-at card40 pos5 pos5)
+	(card-at card41 pos6 pos5)
+	(card-at card42 pos0 pos6)
+	(card-at card43 pos1 pos6)
+	(card-at card44 pos2 pos6)
+	(card-at card45 pos3 pos6)
+	(card-at card46 pos4 pos6)
+	(card-at card47 pos5 pos6)
+	(card-at card48 pos6 pos6)
+
+	(BLOCKED card0 N)
+	(BLOCKED card0 W)
+
+	(BLOCKED card1 N)
+	(BLOCKED card1 E)
+
+	(BLOCKED card2 N)
+	(BLOCKED card2 E)
+
+	(BLOCKED card3 E)
+	(BLOCKED card3 W)
+
+	(BLOCKED card4 N)
+	(BLOCKED card4 S)
+
+	(BLOCKED card5 E)
+	(BLOCKED card5 S)
+
+	(BLOCKED card6 E)
+	(BLOCKED card6 S)
+
+	(BLOCKED card7 N)
+
+	(BLOCKED card8 S)
+
+	(BLOCKED card9 N)
+
+	(BLOCKED card10 S)
+	(BLOCKED card10 W)
+
+	(BLOCKED card11 S)
+	(BLOCKED card11 W)
+
+	(BLOCKED card12 W)
+
+	(BLOCKED card13 E)
+
+	(BLOCKED card14 W)
+
+	(BLOCKED card15 N)
+	(BLOCKED card15 W)
+
+	(BLOCKED card16 S)
+	(BLOCKED card16 W)
+
+	(BLOCKED card17 N)
+	(BLOCKED card17 S)
+
+	(BLOCKED card18 E)
+	(BLOCKED card18 W)
+
+	(BLOCKED card19 N)
+	(BLOCKED card19 W)
+
+	(BLOCKED card20 N)
+	(BLOCKED card20 E)
+
+	(BLOCKED card21 E)
+	(BLOCKED card21 W)
+
+	(BLOCKED card22 E)
+	(BLOCKED card22 W)
+
+	(BLOCKED card23 S)
+	(BLOCKED card23 W)
+
+	(BLOCKED card24 N)
+	(BLOCKED card24 S)
+
+	(BLOCKED card25 E)
+	(BLOCKED card25 W)
+
+	(BLOCKED card26 E)
+
+	(BLOCKED card27 E)
+	(BLOCKED card27 W)
+
+	(BLOCKED card29 N)
+	(BLOCKED card29 S)
+
+	(BLOCKED card30 E)
+
+	(BLOCKED card31 N)
+	(BLOCKED card31 W)
+
+	(BLOCKED card32 N)
+	(BLOCKED card32 E)
+
+	(BLOCKED card33 S)
+	(BLOCKED card33 W)
+
+
+	(BLOCKED card28 S)
+
+	(BLOCKED card35 E)
+	(BLOCKED card35 S)
+
+	(BLOCKED card36 N)
+	(BLOCKED card36 E)
+
+	(BLOCKED card37 S)
+	(BLOCKED card37 W)
+
+	(BLOCKED card38 E)
+	(BLOCKED card38 S)
+
+	(BLOCKED card39 S)
+	(BLOCKED card39 W)
+
+	(BLOCKED card40 E)
+
+	(BLOCKED card41 S)
+	(BLOCKED card41 W)
+
+	(BLOCKED card42 S)
+	(BLOCKED card42 W)
+
+	(BLOCKED card43 E)
+	(BLOCKED card43 W)
+
+	(BLOCKED card44 W)
+
+	(BLOCKED card45 N)
+	(BLOCKED card45 S)
+
+	(BLOCKED card46 N)
+	(BLOCKED card46 W)
+
+	(BLOCKED card47 S)
+	(BLOCKED card47 W)
+
+	(BLOCKED card48 N)
+
+
+	(robot-at card0)
+
+	(not-robot-at card48)
+	(not-robot-at card47)
+	(not-robot-at card46)
+	(not-robot-at card45)
+	(not-robot-at card44)
+	(not-robot-at card43)
+	(not-robot-at card42)
+	(not-robot-at card41)
+	(not-robot-at card40)
+	(not-robot-at card39)
+	(not-robot-at card38)
+	(not-robot-at card37)
+	(not-robot-at card36)
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/OPT/p16.pddl
+++ b/labyrinth/OPT/p16.pddl
@@ -1,0 +1,425 @@
+;; Generated with seed: 1321, size: 7, num-rotations: 2
+(define (problem labyrinth-size-7-rotations-2-seed-1321)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5 pos6  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35 card36 card37 card38 card39 card40 card41 card42 card43 card44 card45 card46 card47 card48  - card
+)
+(:init
+	(NOT-BLOCKED card48 W)
+	(NOT-BLOCKED card48 S)
+
+	(NOT-BLOCKED card47 W)
+	(NOT-BLOCKED card47 S)
+	(NOT-BLOCKED card47 E)
+
+	(NOT-BLOCKED card46 W)
+	(NOT-BLOCKED card46 S)
+	(NOT-BLOCKED card46 E)
+
+	(NOT-BLOCKED card45 W)
+	(NOT-BLOCKED card45 S)
+	(NOT-BLOCKED card45 E)
+
+	(NOT-BLOCKED card44 W)
+	(NOT-BLOCKED card44 E)
+	(NOT-BLOCKED card44 N)
+
+	(NOT-BLOCKED card43 W)
+	(NOT-BLOCKED card43 S)
+	(NOT-BLOCKED card43 E)
+
+	(NOT-BLOCKED card42 E)
+	(NOT-BLOCKED card42 N)
+
+	(NOT-BLOCKED card41 E)
+	(NOT-BLOCKED card41 N)
+
+	(NOT-BLOCKED card40 S)
+	(NOT-BLOCKED card40 N)
+
+	(NOT-BLOCKED card39 W)
+	(NOT-BLOCKED card39 E)
+	(NOT-BLOCKED card39 N)
+
+	(NOT-BLOCKED card38 S)
+	(NOT-BLOCKED card38 E)
+
+	(NOT-BLOCKED card37 W)
+	(NOT-BLOCKED card37 S)
+
+	(NOT-BLOCKED card36 W)
+	(NOT-BLOCKED card36 S)
+	(NOT-BLOCKED card36 N)
+
+	(NOT-BLOCKED card35 S)
+	(NOT-BLOCKED card35 N)
+
+	(NOT-BLOCKED card34 W)
+	(NOT-BLOCKED card34 S)
+
+	(NOT-BLOCKED card33 W)
+	(NOT-BLOCKED card33 E)
+
+	(NOT-BLOCKED card32 S)
+	(NOT-BLOCKED card32 N)
+
+	(NOT-BLOCKED card31 S)
+	(NOT-BLOCKED card31 N)
+
+	(NOT-BLOCKED card30 W)
+	(NOT-BLOCKED card30 N)
+
+	(NOT-BLOCKED card29 W)
+	(NOT-BLOCKED card29 S)
+	(NOT-BLOCKED card29 E)
+	(NOT-BLOCKED card29 N)
+
+	(NOT-BLOCKED card28 S)
+	(NOT-BLOCKED card28 N)
+
+	(NOT-BLOCKED card27 E)
+	(NOT-BLOCKED card27 N)
+
+	(NOT-BLOCKED card26 E)
+	(NOT-BLOCKED card26 N)
+
+	(NOT-BLOCKED card25 S)
+	(NOT-BLOCKED card25 E)
+
+	(NOT-BLOCKED card24 W)
+	(NOT-BLOCKED card24 N)
+
+	(NOT-BLOCKED card23 W)
+	(NOT-BLOCKED card23 N)
+
+	(NOT-BLOCKED card22 W)
+	(NOT-BLOCKED card22 E)
+	(NOT-BLOCKED card22 N)
+
+	(NOT-BLOCKED card21 S)
+	(NOT-BLOCKED card21 N)
+
+	(NOT-BLOCKED card20 S)
+	(NOT-BLOCKED card20 E)
+	(NOT-BLOCKED card20 N)
+
+	(NOT-BLOCKED card19 W)
+	(NOT-BLOCKED card19 S)
+	(NOT-BLOCKED card19 N)
+
+	(NOT-BLOCKED card18 W)
+	(NOT-BLOCKED card18 S)
+
+	(NOT-BLOCKED card17 E)
+	(NOT-BLOCKED card17 N)
+
+	(NOT-BLOCKED card16 W)
+	(NOT-BLOCKED card16 N)
+
+	(NOT-BLOCKED card15 S)
+	(NOT-BLOCKED card15 E)
+
+	(NOT-BLOCKED card14 S)
+	(NOT-BLOCKED card14 E)
+	(NOT-BLOCKED card14 N)
+
+	(NOT-BLOCKED card13 S)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 W)
+	(NOT-BLOCKED card12 E)
+
+	(NOT-BLOCKED card11 W)
+	(NOT-BLOCKED card11 S)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 W)
+	(NOT-BLOCKED card10 S)
+
+	(NOT-BLOCKED card9 W)
+	(NOT-BLOCKED card9 S)
+	(NOT-BLOCKED card9 N)
+
+	(NOT-BLOCKED card8 E)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 W)
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 E)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 S)
+	(NOT-BLOCKED card6 E)
+
+	(NOT-BLOCKED card5 S)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 S)
+	(NOT-BLOCKED card4 E)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 E)
+
+	(NOT-BLOCKED card2 E)
+	(NOT-BLOCKED card2 N)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 E)
+
+	(NOT-BLOCKED card0 S)
+	(NOT-BLOCKED card0 E)
+
+	(MAX-POS pos6)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+	(NEXT pos6 pos5)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card5 pos5 pos0)
+	(card-at card6 pos6 pos0)
+	(card-at card8 pos0 pos1)
+	(card-at card9 pos1 pos1)
+	(card-at card10 pos2 pos1)
+	(card-at card11 pos3 pos1)
+	(card-at card12 pos4 pos1)
+	(card-at card13 pos5 pos1)
+	(card-at card7 pos6 pos1)
+	(card-at card14 pos0 pos2)
+	(card-at card15 pos1 pos2)
+	(card-at card16 pos2 pos2)
+	(card-at card17 pos3 pos2)
+	(card-at card18 pos4 pos2)
+	(card-at card19 pos5 pos2)
+	(card-at card20 pos6 pos2)
+	(card-at card22 pos0 pos3)
+	(card-at card23 pos1 pos3)
+	(card-at card24 pos2 pos3)
+	(card-at card25 pos3 pos3)
+	(card-at card26 pos4 pos3)
+	(card-at card27 pos5 pos3)
+	(card-at card21 pos6 pos3)
+	(card-at card28 pos0 pos4)
+	(card-at card29 pos1 pos4)
+	(card-at card30 pos2 pos4)
+	(card-at card31 pos3 pos4)
+	(card-at card32 pos4 pos4)
+	(card-at card33 pos5 pos4)
+	(card-at card34 pos6 pos4)
+	(card-at card35 pos0 pos5)
+	(card-at card36 pos1 pos5)
+	(card-at card37 pos2 pos5)
+	(card-at card38 pos3 pos5)
+	(card-at card39 pos4 pos5)
+	(card-at card40 pos5 pos5)
+	(card-at card41 pos6 pos5)
+	(card-at card42 pos0 pos6)
+	(card-at card43 pos1 pos6)
+	(card-at card44 pos2 pos6)
+	(card-at card45 pos3 pos6)
+	(card-at card46 pos4 pos6)
+	(card-at card47 pos5 pos6)
+	(card-at card48 pos6 pos6)
+
+	(BLOCKED card0 N)
+	(BLOCKED card0 W)
+
+	(BLOCKED card1 N)
+	(BLOCKED card1 S)
+
+	(BLOCKED card2 S)
+	(BLOCKED card2 W)
+
+	(BLOCKED card3 N)
+	(BLOCKED card3 S)
+
+	(BLOCKED card4 N)
+
+	(BLOCKED card5 E)
+	(BLOCKED card5 W)
+
+	(BLOCKED card6 N)
+	(BLOCKED card6 W)
+
+	(BLOCKED card8 S)
+	(BLOCKED card8 W)
+
+	(BLOCKED card9 E)
+
+	(BLOCKED card10 N)
+	(BLOCKED card10 E)
+
+	(BLOCKED card11 E)
+
+	(BLOCKED card12 N)
+	(BLOCKED card12 S)
+
+	(BLOCKED card13 E)
+	(BLOCKED card13 W)
+
+
+	(BLOCKED card14 W)
+
+	(BLOCKED card15 N)
+	(BLOCKED card15 W)
+
+	(BLOCKED card16 E)
+	(BLOCKED card16 S)
+
+	(BLOCKED card17 S)
+	(BLOCKED card17 W)
+
+	(BLOCKED card18 N)
+	(BLOCKED card18 E)
+
+	(BLOCKED card19 E)
+
+	(BLOCKED card20 W)
+
+	(BLOCKED card22 S)
+
+	(BLOCKED card23 E)
+	(BLOCKED card23 S)
+
+	(BLOCKED card24 E)
+	(BLOCKED card24 S)
+
+	(BLOCKED card25 N)
+	(BLOCKED card25 W)
+
+	(BLOCKED card26 S)
+	(BLOCKED card26 W)
+
+	(BLOCKED card27 S)
+	(BLOCKED card27 W)
+
+	(BLOCKED card21 E)
+	(BLOCKED card21 W)
+
+	(BLOCKED card28 E)
+	(BLOCKED card28 W)
+
+
+	(BLOCKED card30 E)
+	(BLOCKED card30 S)
+
+	(BLOCKED card31 E)
+	(BLOCKED card31 W)
+
+	(BLOCKED card32 E)
+	(BLOCKED card32 W)
+
+	(BLOCKED card33 N)
+	(BLOCKED card33 S)
+
+	(BLOCKED card34 N)
+	(BLOCKED card34 E)
+
+	(BLOCKED card35 E)
+	(BLOCKED card35 W)
+
+	(BLOCKED card36 E)
+
+	(BLOCKED card37 N)
+	(BLOCKED card37 E)
+
+	(BLOCKED card38 N)
+	(BLOCKED card38 W)
+
+	(BLOCKED card39 S)
+
+	(BLOCKED card40 E)
+	(BLOCKED card40 W)
+
+	(BLOCKED card41 S)
+	(BLOCKED card41 W)
+
+	(BLOCKED card42 S)
+	(BLOCKED card42 W)
+
+	(BLOCKED card43 N)
+
+	(BLOCKED card44 S)
+
+	(BLOCKED card45 N)
+
+	(BLOCKED card46 N)
+
+	(BLOCKED card47 N)
+
+	(BLOCKED card48 N)
+	(BLOCKED card48 E)
+
+
+	(robot-at card0)
+
+	(not-robot-at card48)
+	(not-robot-at card47)
+	(not-robot-at card46)
+	(not-robot-at card45)
+	(not-robot-at card44)
+	(not-robot-at card43)
+	(not-robot-at card42)
+	(not-robot-at card41)
+	(not-robot-at card40)
+	(not-robot-at card39)
+	(not-robot-at card38)
+	(not-robot-at card37)
+	(not-robot-at card36)
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/OPT/p17.pddl
+++ b/labyrinth/OPT/p17.pddl
@@ -1,0 +1,425 @@
+;; Generated with seed: 1327, size: 7, num-rotations: 3
+(define (problem labyrinth-size-7-rotations-3-seed-1327)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5 pos6  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35 card36 card37 card38 card39 card40 card41 card42 card43 card44 card45 card46 card47 card48  - card
+)
+(:init
+	(NOT-BLOCKED card48 W)
+	(NOT-BLOCKED card48 S)
+	(NOT-BLOCKED card48 E)
+	(NOT-BLOCKED card48 N)
+
+	(NOT-BLOCKED card47 W)
+	(NOT-BLOCKED card47 E)
+	(NOT-BLOCKED card47 N)
+
+	(NOT-BLOCKED card46 W)
+	(NOT-BLOCKED card46 E)
+
+	(NOT-BLOCKED card45 W)
+	(NOT-BLOCKED card45 N)
+
+	(NOT-BLOCKED card44 S)
+	(NOT-BLOCKED card44 N)
+
+	(NOT-BLOCKED card43 S)
+	(NOT-BLOCKED card43 E)
+	(NOT-BLOCKED card43 N)
+
+	(NOT-BLOCKED card42 S)
+	(NOT-BLOCKED card42 N)
+
+	(NOT-BLOCKED card41 W)
+	(NOT-BLOCKED card41 S)
+	(NOT-BLOCKED card41 E)
+	(NOT-BLOCKED card41 N)
+
+	(NOT-BLOCKED card40 W)
+	(NOT-BLOCKED card40 N)
+
+	(NOT-BLOCKED card39 W)
+	(NOT-BLOCKED card39 N)
+
+	(NOT-BLOCKED card38 E)
+	(NOT-BLOCKED card38 N)
+
+	(NOT-BLOCKED card37 W)
+	(NOT-BLOCKED card37 E)
+
+	(NOT-BLOCKED card36 S)
+	(NOT-BLOCKED card36 N)
+
+	(NOT-BLOCKED card35 S)
+	(NOT-BLOCKED card35 E)
+
+	(NOT-BLOCKED card34 S)
+	(NOT-BLOCKED card34 N)
+
+	(NOT-BLOCKED card33 S)
+	(NOT-BLOCKED card33 E)
+
+	(NOT-BLOCKED card32 W)
+	(NOT-BLOCKED card32 E)
+
+	(NOT-BLOCKED card31 S)
+	(NOT-BLOCKED card31 N)
+
+	(NOT-BLOCKED card30 S)
+	(NOT-BLOCKED card30 E)
+
+	(NOT-BLOCKED card29 W)
+	(NOT-BLOCKED card29 E)
+
+	(NOT-BLOCKED card28 E)
+	(NOT-BLOCKED card28 N)
+
+	(NOT-BLOCKED card27 W)
+	(NOT-BLOCKED card27 S)
+	(NOT-BLOCKED card27 E)
+	(NOT-BLOCKED card27 N)
+
+	(NOT-BLOCKED card26 W)
+	(NOT-BLOCKED card26 N)
+
+	(NOT-BLOCKED card25 W)
+	(NOT-BLOCKED card25 E)
+	(NOT-BLOCKED card25 N)
+
+	(NOT-BLOCKED card24 W)
+	(NOT-BLOCKED card24 S)
+
+	(NOT-BLOCKED card23 W)
+	(NOT-BLOCKED card23 E)
+
+	(NOT-BLOCKED card22 W)
+	(NOT-BLOCKED card22 S)
+	(NOT-BLOCKED card22 N)
+
+	(NOT-BLOCKED card21 W)
+	(NOT-BLOCKED card21 S)
+
+	(NOT-BLOCKED card20 W)
+	(NOT-BLOCKED card20 S)
+	(NOT-BLOCKED card20 E)
+
+	(NOT-BLOCKED card19 S)
+	(NOT-BLOCKED card19 E)
+
+	(NOT-BLOCKED card18 W)
+	(NOT-BLOCKED card18 S)
+	(NOT-BLOCKED card18 E)
+
+	(NOT-BLOCKED card17 E)
+	(NOT-BLOCKED card17 N)
+
+	(NOT-BLOCKED card16 W)
+	(NOT-BLOCKED card16 S)
+
+	(NOT-BLOCKED card15 E)
+	(NOT-BLOCKED card15 N)
+
+	(NOT-BLOCKED card14 W)
+	(NOT-BLOCKED card14 S)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 E)
+
+	(NOT-BLOCKED card12 W)
+	(NOT-BLOCKED card12 E)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 W)
+	(NOT-BLOCKED card11 S)
+	(NOT-BLOCKED card11 E)
+
+	(NOT-BLOCKED card10 S)
+	(NOT-BLOCKED card10 E)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 S)
+	(NOT-BLOCKED card9 E)
+	(NOT-BLOCKED card9 N)
+
+	(NOT-BLOCKED card8 W)
+	(NOT-BLOCKED card8 S)
+
+	(NOT-BLOCKED card7 W)
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 E)
+
+	(NOT-BLOCKED card6 W)
+	(NOT-BLOCKED card6 E)
+
+	(NOT-BLOCKED card5 W)
+	(NOT-BLOCKED card5 S)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 S)
+	(NOT-BLOCKED card4 E)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 E)
+	(NOT-BLOCKED card3 N)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 S)
+	(NOT-BLOCKED card2 E)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 S)
+	(NOT-BLOCKED card1 E)
+
+	(NOT-BLOCKED card0 W)
+	(NOT-BLOCKED card0 E)
+
+	(MAX-POS pos6)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+	(NEXT pos6 pos5)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card10 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card47 pos5 pos0)
+	(card-at card6 pos6 pos0)
+	(card-at card13 pos0 pos1)
+	(card-at card7 pos1 pos1)
+	(card-at card8 pos2 pos1)
+	(card-at card9 pos3 pos1)
+	(card-at card17 pos4 pos1)
+	(card-at card11 pos5 pos1)
+	(card-at card5 pos6 pos1)
+	(card-at card14 pos0 pos2)
+	(card-at card15 pos1 pos2)
+	(card-at card16 pos2 pos2)
+	(card-at card24 pos3 pos2)
+	(card-at card18 pos4 pos2)
+	(card-at card12 pos5 pos2)
+	(card-at card20 pos6 pos2)
+	(card-at card21 pos0 pos3)
+	(card-at card22 pos1 pos3)
+	(card-at card23 pos2 pos3)
+	(card-at card31 pos3 pos3)
+	(card-at card25 pos4 pos3)
+	(card-at card19 pos5 pos3)
+	(card-at card27 pos6 pos3)
+	(card-at card28 pos0 pos4)
+	(card-at card29 pos1 pos4)
+	(card-at card30 pos2 pos4)
+	(card-at card38 pos3 pos4)
+	(card-at card32 pos4 pos4)
+	(card-at card26 pos5 pos4)
+	(card-at card34 pos6 pos4)
+	(card-at card35 pos0 pos5)
+	(card-at card36 pos1 pos5)
+	(card-at card37 pos2 pos5)
+	(card-at card45 pos3 pos5)
+	(card-at card39 pos4 pos5)
+	(card-at card33 pos5 pos5)
+	(card-at card41 pos6 pos5)
+	(card-at card42 pos0 pos6)
+	(card-at card43 pos1 pos6)
+	(card-at card44 pos2 pos6)
+	(card-at card3 pos3 pos6)
+	(card-at card46 pos4 pos6)
+	(card-at card40 pos5 pos6)
+	(card-at card48 pos6 pos6)
+
+	(BLOCKED card0 N)
+	(BLOCKED card0 S)
+
+	(BLOCKED card1 N)
+
+	(BLOCKED card2 N)
+
+	(BLOCKED card10 W)
+
+	(BLOCKED card4 N)
+
+	(BLOCKED card47 S)
+
+	(BLOCKED card6 N)
+	(BLOCKED card6 S)
+
+	(BLOCKED card13 N)
+	(BLOCKED card13 S)
+
+	(BLOCKED card7 N)
+
+	(BLOCKED card8 N)
+	(BLOCKED card8 E)
+
+	(BLOCKED card9 W)
+
+	(BLOCKED card17 S)
+	(BLOCKED card17 W)
+
+	(BLOCKED card11 N)
+
+	(BLOCKED card5 N)
+	(BLOCKED card5 E)
+
+	(BLOCKED card14 N)
+	(BLOCKED card14 E)
+
+	(BLOCKED card15 S)
+	(BLOCKED card15 W)
+
+	(BLOCKED card16 N)
+	(BLOCKED card16 E)
+
+	(BLOCKED card24 N)
+	(BLOCKED card24 E)
+
+	(BLOCKED card18 N)
+
+	(BLOCKED card12 S)
+
+	(BLOCKED card20 N)
+
+	(BLOCKED card21 N)
+	(BLOCKED card21 E)
+
+	(BLOCKED card22 E)
+
+	(BLOCKED card23 N)
+	(BLOCKED card23 S)
+
+	(BLOCKED card31 E)
+	(BLOCKED card31 W)
+
+	(BLOCKED card25 S)
+
+	(BLOCKED card19 N)
+	(BLOCKED card19 W)
+
+
+	(BLOCKED card28 S)
+	(BLOCKED card28 W)
+
+	(BLOCKED card29 N)
+	(BLOCKED card29 S)
+
+	(BLOCKED card30 N)
+	(BLOCKED card30 W)
+
+	(BLOCKED card38 S)
+	(BLOCKED card38 W)
+
+	(BLOCKED card32 N)
+	(BLOCKED card32 S)
+
+	(BLOCKED card26 E)
+	(BLOCKED card26 S)
+
+	(BLOCKED card34 E)
+	(BLOCKED card34 W)
+
+	(BLOCKED card35 N)
+	(BLOCKED card35 W)
+
+	(BLOCKED card36 E)
+	(BLOCKED card36 W)
+
+	(BLOCKED card37 N)
+	(BLOCKED card37 S)
+
+	(BLOCKED card45 E)
+	(BLOCKED card45 S)
+
+	(BLOCKED card39 E)
+	(BLOCKED card39 S)
+
+	(BLOCKED card33 N)
+	(BLOCKED card33 W)
+
+
+	(BLOCKED card42 E)
+	(BLOCKED card42 W)
+
+	(BLOCKED card43 W)
+
+	(BLOCKED card44 E)
+	(BLOCKED card44 W)
+
+	(BLOCKED card3 S)
+
+	(BLOCKED card46 N)
+	(BLOCKED card46 S)
+
+	(BLOCKED card40 E)
+	(BLOCKED card40 S)
+
+
+
+	(robot-at card0)
+
+	(not-robot-at card48)
+	(not-robot-at card47)
+	(not-robot-at card46)
+	(not-robot-at card45)
+	(not-robot-at card44)
+	(not-robot-at card43)
+	(not-robot-at card42)
+	(not-robot-at card41)
+	(not-robot-at card40)
+	(not-robot-at card39)
+	(not-robot-at card38)
+	(not-robot-at card37)
+	(not-robot-at card36)
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/OPT/p18.pddl
+++ b/labyrinth/OPT/p18.pddl
@@ -1,0 +1,425 @@
+;; Generated with seed: 1361, size: 7, num-rotations: 4
+(define (problem labyrinth-size-7-rotations-4-seed-1361)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5 pos6  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35 card36 card37 card38 card39 card40 card41 card42 card43 card44 card45 card46 card47 card48  - card
+)
+(:init
+	(NOT-BLOCKED card48 W)
+	(NOT-BLOCKED card48 S)
+	(NOT-BLOCKED card48 N)
+
+	(NOT-BLOCKED card47 W)
+	(NOT-BLOCKED card47 E)
+	(NOT-BLOCKED card47 N)
+
+	(NOT-BLOCKED card46 E)
+	(NOT-BLOCKED card46 N)
+
+	(NOT-BLOCKED card45 E)
+	(NOT-BLOCKED card45 N)
+
+	(NOT-BLOCKED card44 W)
+	(NOT-BLOCKED card44 N)
+
+	(NOT-BLOCKED card43 W)
+	(NOT-BLOCKED card43 S)
+	(NOT-BLOCKED card43 E)
+
+	(NOT-BLOCKED card42 E)
+	(NOT-BLOCKED card42 N)
+
+	(NOT-BLOCKED card41 S)
+	(NOT-BLOCKED card41 N)
+
+	(NOT-BLOCKED card40 W)
+	(NOT-BLOCKED card40 N)
+
+	(NOT-BLOCKED card39 S)
+	(NOT-BLOCKED card39 E)
+	(NOT-BLOCKED card39 N)
+
+	(NOT-BLOCKED card38 W)
+	(NOT-BLOCKED card38 E)
+
+	(NOT-BLOCKED card37 W)
+	(NOT-BLOCKED card37 E)
+	(NOT-BLOCKED card37 N)
+
+	(NOT-BLOCKED card36 W)
+	(NOT-BLOCKED card36 S)
+
+	(NOT-BLOCKED card35 W)
+	(NOT-BLOCKED card35 S)
+	(NOT-BLOCKED card35 E)
+
+	(NOT-BLOCKED card34 S)
+	(NOT-BLOCKED card34 N)
+
+	(NOT-BLOCKED card33 W)
+	(NOT-BLOCKED card33 S)
+	(NOT-BLOCKED card33 N)
+
+	(NOT-BLOCKED card32 W)
+	(NOT-BLOCKED card32 N)
+
+	(NOT-BLOCKED card31 W)
+	(NOT-BLOCKED card31 N)
+
+	(NOT-BLOCKED card30 W)
+	(NOT-BLOCKED card30 S)
+
+	(NOT-BLOCKED card29 S)
+	(NOT-BLOCKED card29 E)
+
+	(NOT-BLOCKED card28 W)
+	(NOT-BLOCKED card28 N)
+
+	(NOT-BLOCKED card27 S)
+	(NOT-BLOCKED card27 N)
+
+	(NOT-BLOCKED card26 E)
+	(NOT-BLOCKED card26 N)
+
+	(NOT-BLOCKED card25 S)
+	(NOT-BLOCKED card25 N)
+
+	(NOT-BLOCKED card24 W)
+	(NOT-BLOCKED card24 S)
+
+	(NOT-BLOCKED card23 W)
+	(NOT-BLOCKED card23 S)
+	(NOT-BLOCKED card23 E)
+
+	(NOT-BLOCKED card22 W)
+	(NOT-BLOCKED card22 N)
+
+	(NOT-BLOCKED card21 S)
+	(NOT-BLOCKED card21 N)
+
+	(NOT-BLOCKED card20 W)
+	(NOT-BLOCKED card20 S)
+
+	(NOT-BLOCKED card19 E)
+	(NOT-BLOCKED card19 N)
+
+	(NOT-BLOCKED card18 W)
+	(NOT-BLOCKED card18 E)
+
+	(NOT-BLOCKED card17 S)
+	(NOT-BLOCKED card17 N)
+
+	(NOT-BLOCKED card16 W)
+	(NOT-BLOCKED card16 S)
+	(NOT-BLOCKED card16 N)
+
+	(NOT-BLOCKED card15 W)
+	(NOT-BLOCKED card15 S)
+	(NOT-BLOCKED card15 E)
+	(NOT-BLOCKED card15 N)
+
+	(NOT-BLOCKED card14 W)
+	(NOT-BLOCKED card14 N)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 E)
+
+	(NOT-BLOCKED card12 W)
+	(NOT-BLOCKED card12 S)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 S)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 W)
+	(NOT-BLOCKED card10 S)
+
+	(NOT-BLOCKED card9 E)
+	(NOT-BLOCKED card9 N)
+
+	(NOT-BLOCKED card8 S)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 W)
+	(NOT-BLOCKED card7 S)
+
+	(NOT-BLOCKED card6 W)
+	(NOT-BLOCKED card6 N)
+
+	(NOT-BLOCKED card5 W)
+	(NOT-BLOCKED card5 S)
+	(NOT-BLOCKED card5 E)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 E)
+	(NOT-BLOCKED card4 N)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 E)
+	(NOT-BLOCKED card3 N)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 E)
+	(NOT-BLOCKED card2 N)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 E)
+
+	(NOT-BLOCKED card0 W)
+	(NOT-BLOCKED card0 E)
+
+	(MAX-POS pos6)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+	(NEXT pos6 pos5)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card44 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card5 pos5 pos0)
+	(card-at card6 pos6 pos0)
+	(card-at card7 pos0 pos1)
+	(card-at card8 pos1 pos1)
+	(card-at card2 pos2 pos1)
+	(card-at card10 pos3 pos1)
+	(card-at card11 pos4 pos1)
+	(card-at card12 pos5 pos1)
+	(card-at card13 pos6 pos1)
+	(card-at card20 pos0 pos2)
+	(card-at card14 pos1 pos2)
+	(card-at card15 pos2 pos2)
+	(card-at card9 pos3 pos2)
+	(card-at card17 pos4 pos2)
+	(card-at card18 pos5 pos2)
+	(card-at card19 pos6 pos2)
+	(card-at card26 pos0 pos3)
+	(card-at card27 pos1 pos3)
+	(card-at card21 pos2 pos3)
+	(card-at card22 pos3 pos3)
+	(card-at card16 pos4 pos3)
+	(card-at card24 pos5 pos3)
+	(card-at card25 pos6 pos3)
+	(card-at card28 pos0 pos4)
+	(card-at card29 pos1 pos4)
+	(card-at card23 pos2 pos4)
+	(card-at card31 pos3 pos4)
+	(card-at card32 pos4 pos4)
+	(card-at card33 pos5 pos4)
+	(card-at card34 pos6 pos4)
+	(card-at card35 pos0 pos5)
+	(card-at card36 pos1 pos5)
+	(card-at card30 pos2 pos5)
+	(card-at card38 pos3 pos5)
+	(card-at card39 pos4 pos5)
+	(card-at card40 pos5 pos5)
+	(card-at card41 pos6 pos5)
+	(card-at card42 pos0 pos6)
+	(card-at card43 pos1 pos6)
+	(card-at card37 pos2 pos6)
+	(card-at card45 pos3 pos6)
+	(card-at card46 pos4 pos6)
+	(card-at card47 pos5 pos6)
+	(card-at card48 pos6 pos6)
+
+	(BLOCKED card0 N)
+	(BLOCKED card0 S)
+
+	(BLOCKED card1 N)
+	(BLOCKED card1 S)
+
+	(BLOCKED card44 E)
+	(BLOCKED card44 S)
+
+	(BLOCKED card3 S)
+
+	(BLOCKED card4 S)
+
+	(BLOCKED card5 N)
+
+	(BLOCKED card6 E)
+	(BLOCKED card6 S)
+
+	(BLOCKED card7 N)
+	(BLOCKED card7 E)
+
+	(BLOCKED card8 E)
+	(BLOCKED card8 W)
+
+	(BLOCKED card2 S)
+
+	(BLOCKED card10 N)
+	(BLOCKED card10 E)
+
+	(BLOCKED card11 E)
+	(BLOCKED card11 W)
+
+	(BLOCKED card12 E)
+
+	(BLOCKED card13 N)
+	(BLOCKED card13 S)
+
+	(BLOCKED card20 N)
+	(BLOCKED card20 E)
+
+	(BLOCKED card14 E)
+	(BLOCKED card14 S)
+
+
+	(BLOCKED card9 S)
+	(BLOCKED card9 W)
+
+	(BLOCKED card17 E)
+	(BLOCKED card17 W)
+
+	(BLOCKED card18 N)
+	(BLOCKED card18 S)
+
+	(BLOCKED card19 S)
+	(BLOCKED card19 W)
+
+	(BLOCKED card26 S)
+	(BLOCKED card26 W)
+
+	(BLOCKED card27 E)
+	(BLOCKED card27 W)
+
+	(BLOCKED card21 E)
+	(BLOCKED card21 W)
+
+	(BLOCKED card22 E)
+	(BLOCKED card22 S)
+
+	(BLOCKED card16 E)
+
+	(BLOCKED card24 N)
+	(BLOCKED card24 E)
+
+	(BLOCKED card25 E)
+	(BLOCKED card25 W)
+
+	(BLOCKED card28 E)
+	(BLOCKED card28 S)
+
+	(BLOCKED card29 N)
+	(BLOCKED card29 W)
+
+	(BLOCKED card23 N)
+
+	(BLOCKED card31 E)
+	(BLOCKED card31 S)
+
+	(BLOCKED card32 E)
+	(BLOCKED card32 S)
+
+	(BLOCKED card33 E)
+
+	(BLOCKED card34 E)
+	(BLOCKED card34 W)
+
+	(BLOCKED card35 N)
+
+	(BLOCKED card36 N)
+	(BLOCKED card36 E)
+
+	(BLOCKED card30 N)
+	(BLOCKED card30 E)
+
+	(BLOCKED card38 N)
+	(BLOCKED card38 S)
+
+	(BLOCKED card39 W)
+
+	(BLOCKED card40 E)
+	(BLOCKED card40 S)
+
+	(BLOCKED card41 E)
+	(BLOCKED card41 W)
+
+	(BLOCKED card42 S)
+	(BLOCKED card42 W)
+
+	(BLOCKED card43 N)
+
+	(BLOCKED card37 S)
+
+	(BLOCKED card45 S)
+	(BLOCKED card45 W)
+
+	(BLOCKED card46 S)
+	(BLOCKED card46 W)
+
+	(BLOCKED card47 S)
+
+	(BLOCKED card48 E)
+
+
+	(robot-at card0)
+
+	(not-robot-at card48)
+	(not-robot-at card47)
+	(not-robot-at card46)
+	(not-robot-at card45)
+	(not-robot-at card44)
+	(not-robot-at card43)
+	(not-robot-at card42)
+	(not-robot-at card41)
+	(not-robot-at card40)
+	(not-robot-at card39)
+	(not-robot-at card38)
+	(not-robot-at card37)
+	(not-robot-at card36)
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/OPT/p19.pddl
+++ b/labyrinth/OPT/p19.pddl
@@ -1,0 +1,546 @@
+;; Generated with seed: 1367, size: 8, num-rotations: 1
+(define (problem labyrinth-size-8-rotations-1-seed-1367)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5 pos6 pos7  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35 card36 card37 card38 card39 card40 card41 card42 card43 card44 card45 card46 card47 card48 card49 card50 card51 card52 card53 card54 card55 card56 card57 card58 card59 card60 card61 card62 card63  - card
+)
+(:init
+	(NOT-BLOCKED card63 W)
+	(NOT-BLOCKED card63 S)
+
+	(NOT-BLOCKED card62 W)
+	(NOT-BLOCKED card62 E)
+
+	(NOT-BLOCKED card61 W)
+	(NOT-BLOCKED card61 E)
+	(NOT-BLOCKED card61 N)
+
+	(NOT-BLOCKED card60 W)
+	(NOT-BLOCKED card60 E)
+
+	(NOT-BLOCKED card59 S)
+	(NOT-BLOCKED card59 E)
+
+	(NOT-BLOCKED card58 S)
+	(NOT-BLOCKED card58 E)
+	(NOT-BLOCKED card58 N)
+
+	(NOT-BLOCKED card57 S)
+	(NOT-BLOCKED card57 E)
+
+	(NOT-BLOCKED card56 S)
+	(NOT-BLOCKED card56 E)
+	(NOT-BLOCKED card56 N)
+
+	(NOT-BLOCKED card55 W)
+	(NOT-BLOCKED card55 S)
+	(NOT-BLOCKED card55 E)
+
+	(NOT-BLOCKED card54 W)
+	(NOT-BLOCKED card54 S)
+	(NOT-BLOCKED card54 E)
+	(NOT-BLOCKED card54 N)
+
+	(NOT-BLOCKED card53 S)
+	(NOT-BLOCKED card53 N)
+
+	(NOT-BLOCKED card52 W)
+	(NOT-BLOCKED card52 E)
+
+	(NOT-BLOCKED card51 S)
+	(NOT-BLOCKED card51 N)
+
+	(NOT-BLOCKED card50 S)
+	(NOT-BLOCKED card50 E)
+
+	(NOT-BLOCKED card49 W)
+	(NOT-BLOCKED card49 S)
+	(NOT-BLOCKED card49 N)
+
+	(NOT-BLOCKED card48 S)
+	(NOT-BLOCKED card48 E)
+	(NOT-BLOCKED card48 N)
+
+	(NOT-BLOCKED card47 S)
+	(NOT-BLOCKED card47 N)
+
+	(NOT-BLOCKED card46 S)
+	(NOT-BLOCKED card46 E)
+
+	(NOT-BLOCKED card45 W)
+	(NOT-BLOCKED card45 S)
+
+	(NOT-BLOCKED card44 W)
+	(NOT-BLOCKED card44 E)
+	(NOT-BLOCKED card44 N)
+
+	(NOT-BLOCKED card43 W)
+	(NOT-BLOCKED card43 S)
+
+	(NOT-BLOCKED card42 S)
+	(NOT-BLOCKED card42 E)
+	(NOT-BLOCKED card42 N)
+
+	(NOT-BLOCKED card41 W)
+	(NOT-BLOCKED card41 E)
+
+	(NOT-BLOCKED card40 S)
+	(NOT-BLOCKED card40 N)
+
+	(NOT-BLOCKED card39 S)
+	(NOT-BLOCKED card39 N)
+
+	(NOT-BLOCKED card38 W)
+	(NOT-BLOCKED card38 N)
+
+	(NOT-BLOCKED card37 W)
+	(NOT-BLOCKED card37 N)
+
+	(NOT-BLOCKED card36 W)
+	(NOT-BLOCKED card36 S)
+	(NOT-BLOCKED card36 N)
+
+	(NOT-BLOCKED card35 E)
+	(NOT-BLOCKED card35 N)
+
+	(NOT-BLOCKED card34 S)
+	(NOT-BLOCKED card34 E)
+
+	(NOT-BLOCKED card33 W)
+	(NOT-BLOCKED card33 S)
+	(NOT-BLOCKED card33 N)
+
+	(NOT-BLOCKED card32 W)
+	(NOT-BLOCKED card32 E)
+
+	(NOT-BLOCKED card31 W)
+	(NOT-BLOCKED card31 S)
+	(NOT-BLOCKED card31 E)
+
+	(NOT-BLOCKED card30 S)
+	(NOT-BLOCKED card30 E)
+
+	(NOT-BLOCKED card29 W)
+	(NOT-BLOCKED card29 E)
+
+	(NOT-BLOCKED card28 E)
+	(NOT-BLOCKED card28 N)
+
+	(NOT-BLOCKED card27 S)
+	(NOT-BLOCKED card27 N)
+
+	(NOT-BLOCKED card26 W)
+	(NOT-BLOCKED card26 N)
+
+	(NOT-BLOCKED card25 W)
+	(NOT-BLOCKED card25 N)
+
+	(NOT-BLOCKED card24 W)
+	(NOT-BLOCKED card24 S)
+
+	(NOT-BLOCKED card23 W)
+	(NOT-BLOCKED card23 S)
+	(NOT-BLOCKED card23 N)
+
+	(NOT-BLOCKED card22 W)
+	(NOT-BLOCKED card22 S)
+
+	(NOT-BLOCKED card21 W)
+	(NOT-BLOCKED card21 N)
+
+	(NOT-BLOCKED card20 S)
+	(NOT-BLOCKED card20 E)
+	(NOT-BLOCKED card20 N)
+
+	(NOT-BLOCKED card19 W)
+	(NOT-BLOCKED card19 S)
+
+	(NOT-BLOCKED card18 W)
+	(NOT-BLOCKED card18 S)
+	(NOT-BLOCKED card18 E)
+	(NOT-BLOCKED card18 N)
+
+	(NOT-BLOCKED card17 S)
+	(NOT-BLOCKED card17 E)
+	(NOT-BLOCKED card17 N)
+
+	(NOT-BLOCKED card16 E)
+	(NOT-BLOCKED card16 N)
+
+	(NOT-BLOCKED card15 W)
+	(NOT-BLOCKED card15 S)
+
+	(NOT-BLOCKED card14 E)
+	(NOT-BLOCKED card14 N)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 W)
+	(NOT-BLOCKED card12 S)
+
+	(NOT-BLOCKED card11 W)
+	(NOT-BLOCKED card11 E)
+
+	(NOT-BLOCKED card10 S)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 W)
+	(NOT-BLOCKED card9 S)
+	(NOT-BLOCKED card9 E)
+
+	(NOT-BLOCKED card8 E)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 W)
+	(NOT-BLOCKED card6 S)
+	(NOT-BLOCKED card6 E)
+
+	(NOT-BLOCKED card5 W)
+	(NOT-BLOCKED card5 S)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 S)
+	(NOT-BLOCKED card4 N)
+
+	(NOT-BLOCKED card3 S)
+	(NOT-BLOCKED card3 E)
+	(NOT-BLOCKED card3 N)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 S)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 S)
+	(NOT-BLOCKED card1 E)
+
+	(NOT-BLOCKED card0 S)
+	(NOT-BLOCKED card0 E)
+
+	(MAX-POS pos7)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+	(NEXT pos6 pos5)
+	(NEXT pos7 pos6)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card13 pos5 pos0)
+	(card-at card6 pos6 pos0)
+	(card-at card7 pos7 pos0)
+	(card-at card8 pos0 pos1)
+	(card-at card9 pos1 pos1)
+	(card-at card10 pos2 pos1)
+	(card-at card11 pos3 pos1)
+	(card-at card12 pos4 pos1)
+	(card-at card21 pos5 pos1)
+	(card-at card14 pos6 pos1)
+	(card-at card15 pos7 pos1)
+	(card-at card16 pos0 pos2)
+	(card-at card17 pos1 pos2)
+	(card-at card18 pos2 pos2)
+	(card-at card19 pos3 pos2)
+	(card-at card20 pos4 pos2)
+	(card-at card29 pos5 pos2)
+	(card-at card22 pos6 pos2)
+	(card-at card23 pos7 pos2)
+	(card-at card24 pos0 pos3)
+	(card-at card25 pos1 pos3)
+	(card-at card26 pos2 pos3)
+	(card-at card27 pos3 pos3)
+	(card-at card28 pos4 pos3)
+	(card-at card37 pos5 pos3)
+	(card-at card30 pos6 pos3)
+	(card-at card31 pos7 pos3)
+	(card-at card32 pos0 pos4)
+	(card-at card33 pos1 pos4)
+	(card-at card34 pos2 pos4)
+	(card-at card35 pos3 pos4)
+	(card-at card36 pos4 pos4)
+	(card-at card45 pos5 pos4)
+	(card-at card38 pos6 pos4)
+	(card-at card39 pos7 pos4)
+	(card-at card40 pos0 pos5)
+	(card-at card41 pos1 pos5)
+	(card-at card42 pos2 pos5)
+	(card-at card43 pos3 pos5)
+	(card-at card44 pos4 pos5)
+	(card-at card53 pos5 pos5)
+	(card-at card46 pos6 pos5)
+	(card-at card47 pos7 pos5)
+	(card-at card48 pos0 pos6)
+	(card-at card49 pos1 pos6)
+	(card-at card50 pos2 pos6)
+	(card-at card51 pos3 pos6)
+	(card-at card52 pos4 pos6)
+	(card-at card61 pos5 pos6)
+	(card-at card54 pos6 pos6)
+	(card-at card55 pos7 pos6)
+	(card-at card56 pos0 pos7)
+	(card-at card57 pos1 pos7)
+	(card-at card58 pos2 pos7)
+	(card-at card59 pos3 pos7)
+	(card-at card60 pos4 pos7)
+	(card-at card5 pos5 pos7)
+	(card-at card62 pos6 pos7)
+	(card-at card63 pos7 pos7)
+
+	(BLOCKED card0 N)
+	(BLOCKED card0 W)
+
+	(BLOCKED card1 N)
+
+	(BLOCKED card2 N)
+	(BLOCKED card2 E)
+
+	(BLOCKED card3 W)
+
+	(BLOCKED card4 E)
+	(BLOCKED card4 W)
+
+	(BLOCKED card13 E)
+	(BLOCKED card13 S)
+
+	(BLOCKED card6 N)
+
+	(BLOCKED card7 E)
+	(BLOCKED card7 W)
+
+	(BLOCKED card8 S)
+	(BLOCKED card8 W)
+
+	(BLOCKED card9 N)
+
+	(BLOCKED card10 E)
+	(BLOCKED card10 W)
+
+	(BLOCKED card11 N)
+	(BLOCKED card11 S)
+
+	(BLOCKED card12 N)
+	(BLOCKED card12 E)
+
+	(BLOCKED card21 E)
+	(BLOCKED card21 S)
+
+	(BLOCKED card14 S)
+	(BLOCKED card14 W)
+
+	(BLOCKED card15 N)
+	(BLOCKED card15 E)
+
+	(BLOCKED card16 S)
+	(BLOCKED card16 W)
+
+	(BLOCKED card17 W)
+
+
+	(BLOCKED card19 N)
+	(BLOCKED card19 E)
+
+	(BLOCKED card20 W)
+
+	(BLOCKED card29 N)
+	(BLOCKED card29 S)
+
+	(BLOCKED card22 N)
+	(BLOCKED card22 E)
+
+	(BLOCKED card23 E)
+
+	(BLOCKED card24 N)
+	(BLOCKED card24 E)
+
+	(BLOCKED card25 E)
+	(BLOCKED card25 S)
+
+	(BLOCKED card26 E)
+	(BLOCKED card26 S)
+
+	(BLOCKED card27 E)
+	(BLOCKED card27 W)
+
+	(BLOCKED card28 S)
+	(BLOCKED card28 W)
+
+	(BLOCKED card37 E)
+	(BLOCKED card37 S)
+
+	(BLOCKED card30 N)
+	(BLOCKED card30 W)
+
+	(BLOCKED card31 N)
+
+	(BLOCKED card32 N)
+	(BLOCKED card32 S)
+
+	(BLOCKED card33 E)
+
+	(BLOCKED card34 N)
+	(BLOCKED card34 W)
+
+	(BLOCKED card35 S)
+	(BLOCKED card35 W)
+
+	(BLOCKED card36 E)
+
+	(BLOCKED card45 N)
+	(BLOCKED card45 E)
+
+	(BLOCKED card38 E)
+	(BLOCKED card38 S)
+
+	(BLOCKED card39 E)
+	(BLOCKED card39 W)
+
+	(BLOCKED card40 E)
+	(BLOCKED card40 W)
+
+	(BLOCKED card41 N)
+	(BLOCKED card41 S)
+
+	(BLOCKED card42 W)
+
+	(BLOCKED card43 N)
+	(BLOCKED card43 E)
+
+	(BLOCKED card44 S)
+
+	(BLOCKED card53 E)
+	(BLOCKED card53 W)
+
+	(BLOCKED card46 N)
+	(BLOCKED card46 W)
+
+	(BLOCKED card47 E)
+	(BLOCKED card47 W)
+
+	(BLOCKED card48 W)
+
+	(BLOCKED card49 E)
+
+	(BLOCKED card50 N)
+	(BLOCKED card50 W)
+
+	(BLOCKED card51 E)
+	(BLOCKED card51 W)
+
+	(BLOCKED card52 N)
+	(BLOCKED card52 S)
+
+	(BLOCKED card61 S)
+
+
+	(BLOCKED card55 N)
+
+	(BLOCKED card56 W)
+
+	(BLOCKED card57 N)
+	(BLOCKED card57 W)
+
+	(BLOCKED card58 W)
+
+	(BLOCKED card59 N)
+	(BLOCKED card59 W)
+
+	(BLOCKED card60 N)
+	(BLOCKED card60 S)
+
+	(BLOCKED card5 E)
+
+	(BLOCKED card62 N)
+	(BLOCKED card62 S)
+
+	(BLOCKED card63 N)
+	(BLOCKED card63 E)
+
+
+	(robot-at card0)
+
+	(not-robot-at card63)
+	(not-robot-at card62)
+	(not-robot-at card61)
+	(not-robot-at card60)
+	(not-robot-at card59)
+	(not-robot-at card58)
+	(not-robot-at card57)
+	(not-robot-at card56)
+	(not-robot-at card55)
+	(not-robot-at card54)
+	(not-robot-at card53)
+	(not-robot-at card52)
+	(not-robot-at card51)
+	(not-robot-at card50)
+	(not-robot-at card49)
+	(not-robot-at card48)
+	(not-robot-at card47)
+	(not-robot-at card46)
+	(not-robot-at card45)
+	(not-robot-at card44)
+	(not-robot-at card43)
+	(not-robot-at card42)
+	(not-robot-at card41)
+	(not-robot-at card40)
+	(not-robot-at card39)
+	(not-robot-at card38)
+	(not-robot-at card37)
+	(not-robot-at card36)
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/OPT/p20.pddl
+++ b/labyrinth/OPT/p20.pddl
@@ -1,0 +1,546 @@
+;; Generated with seed: 1373, size: 8, num-rotations: 2
+(define (problem labyrinth-size-8-rotations-2-seed-1373)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5 pos6 pos7  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35 card36 card37 card38 card39 card40 card41 card42 card43 card44 card45 card46 card47 card48 card49 card50 card51 card52 card53 card54 card55 card56 card57 card58 card59 card60 card61 card62 card63  - card
+)
+(:init
+	(NOT-BLOCKED card63 S)
+	(NOT-BLOCKED card63 N)
+
+	(NOT-BLOCKED card62 W)
+	(NOT-BLOCKED card62 S)
+	(NOT-BLOCKED card62 E)
+
+	(NOT-BLOCKED card61 W)
+	(NOT-BLOCKED card61 N)
+
+	(NOT-BLOCKED card60 W)
+	(NOT-BLOCKED card60 E)
+
+	(NOT-BLOCKED card59 E)
+	(NOT-BLOCKED card59 N)
+
+	(NOT-BLOCKED card58 S)
+	(NOT-BLOCKED card58 N)
+
+	(NOT-BLOCKED card57 S)
+	(NOT-BLOCKED card57 N)
+
+	(NOT-BLOCKED card56 W)
+	(NOT-BLOCKED card56 S)
+	(NOT-BLOCKED card56 E)
+
+	(NOT-BLOCKED card55 W)
+	(NOT-BLOCKED card55 S)
+
+	(NOT-BLOCKED card54 W)
+	(NOT-BLOCKED card54 S)
+	(NOT-BLOCKED card54 E)
+
+	(NOT-BLOCKED card53 S)
+	(NOT-BLOCKED card53 E)
+	(NOT-BLOCKED card53 N)
+
+	(NOT-BLOCKED card52 S)
+	(NOT-BLOCKED card52 E)
+
+	(NOT-BLOCKED card51 W)
+	(NOT-BLOCKED card51 S)
+
+	(NOT-BLOCKED card50 W)
+	(NOT-BLOCKED card50 N)
+
+	(NOT-BLOCKED card49 S)
+	(NOT-BLOCKED card49 N)
+
+	(NOT-BLOCKED card48 W)
+	(NOT-BLOCKED card48 S)
+
+	(NOT-BLOCKED card47 S)
+	(NOT-BLOCKED card47 N)
+
+	(NOT-BLOCKED card46 S)
+	(NOT-BLOCKED card46 E)
+
+	(NOT-BLOCKED card45 W)
+	(NOT-BLOCKED card45 S)
+
+	(NOT-BLOCKED card44 W)
+	(NOT-BLOCKED card44 S)
+	(NOT-BLOCKED card44 E)
+
+	(NOT-BLOCKED card43 E)
+	(NOT-BLOCKED card43 N)
+
+	(NOT-BLOCKED card42 W)
+	(NOT-BLOCKED card42 S)
+
+	(NOT-BLOCKED card41 W)
+	(NOT-BLOCKED card41 E)
+
+	(NOT-BLOCKED card40 W)
+	(NOT-BLOCKED card40 E)
+
+	(NOT-BLOCKED card39 E)
+	(NOT-BLOCKED card39 N)
+
+	(NOT-BLOCKED card38 S)
+	(NOT-BLOCKED card38 E)
+
+	(NOT-BLOCKED card37 E)
+	(NOT-BLOCKED card37 N)
+
+	(NOT-BLOCKED card36 W)
+	(NOT-BLOCKED card36 S)
+	(NOT-BLOCKED card36 E)
+
+	(NOT-BLOCKED card35 S)
+	(NOT-BLOCKED card35 N)
+
+	(NOT-BLOCKED card34 W)
+	(NOT-BLOCKED card34 S)
+
+	(NOT-BLOCKED card33 S)
+	(NOT-BLOCKED card33 E)
+
+	(NOT-BLOCKED card32 W)
+	(NOT-BLOCKED card32 S)
+
+	(NOT-BLOCKED card31 W)
+	(NOT-BLOCKED card31 S)
+
+	(NOT-BLOCKED card30 W)
+	(NOT-BLOCKED card30 S)
+	(NOT-BLOCKED card30 N)
+
+	(NOT-BLOCKED card29 W)
+	(NOT-BLOCKED card29 E)
+
+	(NOT-BLOCKED card28 S)
+	(NOT-BLOCKED card28 E)
+
+	(NOT-BLOCKED card27 W)
+	(NOT-BLOCKED card27 S)
+	(NOT-BLOCKED card27 N)
+
+	(NOT-BLOCKED card26 W)
+	(NOT-BLOCKED card26 S)
+	(NOT-BLOCKED card26 E)
+
+	(NOT-BLOCKED card25 S)
+	(NOT-BLOCKED card25 E)
+	(NOT-BLOCKED card25 N)
+
+	(NOT-BLOCKED card24 W)
+	(NOT-BLOCKED card24 E)
+
+	(NOT-BLOCKED card23 S)
+	(NOT-BLOCKED card23 E)
+
+	(NOT-BLOCKED card22 W)
+	(NOT-BLOCKED card22 E)
+	(NOT-BLOCKED card22 N)
+
+	(NOT-BLOCKED card21 S)
+	(NOT-BLOCKED card21 E)
+
+	(NOT-BLOCKED card20 S)
+	(NOT-BLOCKED card20 E)
+
+	(NOT-BLOCKED card19 S)
+	(NOT-BLOCKED card19 N)
+
+	(NOT-BLOCKED card18 S)
+	(NOT-BLOCKED card18 N)
+
+	(NOT-BLOCKED card17 W)
+	(NOT-BLOCKED card17 S)
+
+	(NOT-BLOCKED card16 E)
+	(NOT-BLOCKED card16 N)
+
+	(NOT-BLOCKED card15 W)
+	(NOT-BLOCKED card15 S)
+	(NOT-BLOCKED card15 E)
+
+	(NOT-BLOCKED card14 W)
+	(NOT-BLOCKED card14 E)
+
+	(NOT-BLOCKED card13 S)
+	(NOT-BLOCKED card13 E)
+
+	(NOT-BLOCKED card12 W)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 W)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 W)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 W)
+	(NOT-BLOCKED card9 E)
+
+	(NOT-BLOCKED card8 S)
+	(NOT-BLOCKED card8 E)
+
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 E)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 W)
+	(NOT-BLOCKED card6 S)
+	(NOT-BLOCKED card6 E)
+	(NOT-BLOCKED card6 N)
+
+	(NOT-BLOCKED card5 E)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 E)
+	(NOT-BLOCKED card4 N)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 S)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 S)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 E)
+
+	(NOT-BLOCKED card0 W)
+	(NOT-BLOCKED card0 E)
+	(NOT-BLOCKED card0 N)
+
+	(MAX-POS pos7)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+	(NEXT pos6 pos5)
+	(NEXT pos7 pos6)
+
+	(card-at card0 pos0 pos0)
+	(card-at card57 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card5 pos5 pos0)
+	(card-at card6 pos6 pos0)
+	(card-at card7 pos7 pos0)
+	(card-at card8 pos0 pos1)
+	(card-at card1 pos1 pos1)
+	(card-at card10 pos2 pos1)
+	(card-at card11 pos3 pos1)
+	(card-at card12 pos4 pos1)
+	(card-at card13 pos5 pos1)
+	(card-at card14 pos6 pos1)
+	(card-at card15 pos7 pos1)
+	(card-at card16 pos0 pos2)
+	(card-at card9 pos1 pos2)
+	(card-at card18 pos2 pos2)
+	(card-at card19 pos3 pos2)
+	(card-at card20 pos4 pos2)
+	(card-at card21 pos5 pos2)
+	(card-at card22 pos6 pos2)
+	(card-at card23 pos7 pos2)
+	(card-at card24 pos0 pos3)
+	(card-at card17 pos1 pos3)
+	(card-at card26 pos2 pos3)
+	(card-at card27 pos3 pos3)
+	(card-at card28 pos4 pos3)
+	(card-at card29 pos5 pos3)
+	(card-at card30 pos6 pos3)
+	(card-at card31 pos7 pos3)
+	(card-at card33 pos0 pos4)
+	(card-at card25 pos1 pos4)
+	(card-at card35 pos2 pos4)
+	(card-at card36 pos3 pos4)
+	(card-at card37 pos4 pos4)
+	(card-at card38 pos5 pos4)
+	(card-at card39 pos6 pos4)
+	(card-at card32 pos7 pos4)
+	(card-at card40 pos0 pos5)
+	(card-at card34 pos1 pos5)
+	(card-at card42 pos2 pos5)
+	(card-at card43 pos3 pos5)
+	(card-at card44 pos4 pos5)
+	(card-at card45 pos5 pos5)
+	(card-at card46 pos6 pos5)
+	(card-at card47 pos7 pos5)
+	(card-at card48 pos0 pos6)
+	(card-at card41 pos1 pos6)
+	(card-at card50 pos2 pos6)
+	(card-at card51 pos3 pos6)
+	(card-at card52 pos4 pos6)
+	(card-at card53 pos5 pos6)
+	(card-at card54 pos6 pos6)
+	(card-at card55 pos7 pos6)
+	(card-at card56 pos0 pos7)
+	(card-at card49 pos1 pos7)
+	(card-at card58 pos2 pos7)
+	(card-at card59 pos3 pos7)
+	(card-at card60 pos4 pos7)
+	(card-at card61 pos5 pos7)
+	(card-at card62 pos6 pos7)
+	(card-at card63 pos7 pos7)
+
+	(BLOCKED card0 S)
+
+	(BLOCKED card57 E)
+	(BLOCKED card57 W)
+
+	(BLOCKED card2 N)
+	(BLOCKED card2 E)
+
+	(BLOCKED card3 N)
+	(BLOCKED card3 E)
+
+	(BLOCKED card4 S)
+	(BLOCKED card4 W)
+
+	(BLOCKED card5 S)
+	(BLOCKED card5 W)
+
+
+	(BLOCKED card7 W)
+
+	(BLOCKED card8 N)
+	(BLOCKED card8 W)
+
+	(BLOCKED card1 N)
+	(BLOCKED card1 S)
+
+	(BLOCKED card10 E)
+	(BLOCKED card10 S)
+
+	(BLOCKED card11 E)
+	(BLOCKED card11 S)
+
+	(BLOCKED card12 E)
+	(BLOCKED card12 S)
+
+	(BLOCKED card13 N)
+	(BLOCKED card13 W)
+
+	(BLOCKED card14 N)
+	(BLOCKED card14 S)
+
+	(BLOCKED card15 N)
+
+	(BLOCKED card16 S)
+	(BLOCKED card16 W)
+
+	(BLOCKED card9 N)
+	(BLOCKED card9 S)
+
+	(BLOCKED card18 E)
+	(BLOCKED card18 W)
+
+	(BLOCKED card19 E)
+	(BLOCKED card19 W)
+
+	(BLOCKED card20 N)
+	(BLOCKED card20 W)
+
+	(BLOCKED card21 N)
+	(BLOCKED card21 W)
+
+	(BLOCKED card22 S)
+
+	(BLOCKED card23 N)
+	(BLOCKED card23 W)
+
+	(BLOCKED card24 N)
+	(BLOCKED card24 S)
+
+	(BLOCKED card17 N)
+	(BLOCKED card17 E)
+
+	(BLOCKED card26 N)
+
+	(BLOCKED card27 E)
+
+	(BLOCKED card28 N)
+	(BLOCKED card28 W)
+
+	(BLOCKED card29 N)
+	(BLOCKED card29 S)
+
+	(BLOCKED card30 E)
+
+	(BLOCKED card31 N)
+	(BLOCKED card31 E)
+
+	(BLOCKED card33 N)
+	(BLOCKED card33 W)
+
+	(BLOCKED card25 W)
+
+	(BLOCKED card35 E)
+	(BLOCKED card35 W)
+
+	(BLOCKED card36 N)
+
+	(BLOCKED card37 S)
+	(BLOCKED card37 W)
+
+	(BLOCKED card38 N)
+	(BLOCKED card38 W)
+
+	(BLOCKED card39 S)
+	(BLOCKED card39 W)
+
+	(BLOCKED card32 N)
+	(BLOCKED card32 E)
+
+	(BLOCKED card40 N)
+	(BLOCKED card40 S)
+
+	(BLOCKED card34 N)
+	(BLOCKED card34 E)
+
+	(BLOCKED card42 N)
+	(BLOCKED card42 E)
+
+	(BLOCKED card43 S)
+	(BLOCKED card43 W)
+
+	(BLOCKED card44 N)
+
+	(BLOCKED card45 N)
+	(BLOCKED card45 E)
+
+	(BLOCKED card46 N)
+	(BLOCKED card46 W)
+
+	(BLOCKED card47 E)
+	(BLOCKED card47 W)
+
+	(BLOCKED card48 N)
+	(BLOCKED card48 E)
+
+	(BLOCKED card41 N)
+	(BLOCKED card41 S)
+
+	(BLOCKED card50 E)
+	(BLOCKED card50 S)
+
+	(BLOCKED card51 N)
+	(BLOCKED card51 E)
+
+	(BLOCKED card52 N)
+	(BLOCKED card52 W)
+
+	(BLOCKED card53 W)
+
+	(BLOCKED card54 N)
+
+	(BLOCKED card55 N)
+	(BLOCKED card55 E)
+
+	(BLOCKED card56 N)
+
+	(BLOCKED card49 E)
+	(BLOCKED card49 W)
+
+	(BLOCKED card58 E)
+	(BLOCKED card58 W)
+
+	(BLOCKED card59 S)
+	(BLOCKED card59 W)
+
+	(BLOCKED card60 N)
+	(BLOCKED card60 S)
+
+	(BLOCKED card61 E)
+	(BLOCKED card61 S)
+
+	(BLOCKED card62 N)
+
+	(BLOCKED card63 E)
+	(BLOCKED card63 W)
+
+
+	(robot-at card0)
+
+	(not-robot-at card63)
+	(not-robot-at card62)
+	(not-robot-at card61)
+	(not-robot-at card60)
+	(not-robot-at card59)
+	(not-robot-at card58)
+	(not-robot-at card57)
+	(not-robot-at card56)
+	(not-robot-at card55)
+	(not-robot-at card54)
+	(not-robot-at card53)
+	(not-robot-at card52)
+	(not-robot-at card51)
+	(not-robot-at card50)
+	(not-robot-at card49)
+	(not-robot-at card48)
+	(not-robot-at card47)
+	(not-robot-at card46)
+	(not-robot-at card45)
+	(not-robot-at card44)
+	(not-robot-at card43)
+	(not-robot-at card42)
+	(not-robot-at card41)
+	(not-robot-at card40)
+	(not-robot-at card39)
+	(not-robot-at card38)
+	(not-robot-at card37)
+	(not-robot-at card36)
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/SAT/domain.pddl
+++ b/labyrinth/SAT/domain.pddl
@@ -1,0 +1,497 @@
+(define (domain labyrinth)
+(:requirements :adl :action-costs)
+
+(:types
+    ;; card with 2 to 4 paths
+    card - object
+    direction - object
+    ;; vertical direction: N S
+    directionV - direction
+    ;; horizontal directions: W E
+    directionH - direction
+    ;; values for positions of the card in the grid
+    gridpos - object
+)
+
+(:constants
+    S N - directionV
+    W E - directionH
+)
+
+(:predicates
+    ;; ordering of values for grid positions ?p1 = ?p2 + 1
+    (NEXT ?p1 - gridpos ?p2 - gridpos)
+    ;; maximal grid index
+    (MAX-POS ?p - gridpos)
+    ;; minimal grid index
+    (MIN-POS ?p - gridpos)
+    ;; moving from ?c in direction ?d is blocked by a wall
+    (BLOCKED ?c - card ?d - direction)
+    ;; robot is located on card ?c
+    (robot-at ?c - card)
+    ;; card ?c is positioned in the grid at ?x ?y
+    (card-at ?c - card ?x - gridpos ?y - gridpos)
+    ;; flag indicating that the robot left the maze e.i. that the goal has been reached
+    (left)
+
+    ;; Inverted predicates that are necessary to remove negative preconditions.
+    (not-cards-moving)
+
+    (NOT-BLOCKED ?c - card ?d - direction)
+
+    (not-robot-at ?c - card)
+
+    ;; flag to indicate that a card is currently moving an the robot cannot move
+    (cards-moving)
+    ;; flags to indicate that a row/column is rotating in the corresponding direction
+    (cards-moving-west)
+    (cards-moving-east)
+    (cards-moving-south)
+    (cards-moving-north)
+    ;; the card whose position needs to be updated next while rotating
+    (next-moving-card ?c - card)
+    ;; the card that was removed to rotate and which needs to be placed at the beginning/end of the row/column
+    (new-headtail-card ?c - card)
+
+)
+
+(:functions
+    (total-cost) - number
+    (move-robot-cost) - number
+    (move-card) - number
+)
+
+;; moves the robot between to cards
+(:action move-west
+    :parameters (?cfrom - card ?xfrom - gridpos ?yfrom - gridpos ?dfrom - directionH ?cto - card ?xto - gridpos ?yto - gridpos ?dto - directionH)
+    :precondition
+        (and
+            (not-cards-moving)
+            (= ?dfrom w)
+            (robot-at ?cfrom)
+            (card-at ?cfrom ?xfrom ?yfrom)
+            (card-at ?cto ?xto ?yto)
+            (next ?xfrom ?xto)
+            (= ?yfrom ?yto)
+            (not (= ?dfrom ?dto))
+            (not-blocked ?cfrom ?dfrom)
+            (not-blocked ?cto ?dto)
+        )
+    :effect
+        (and
+            (not (robot-at ?cfrom))
+            (not-robot-at ?cfrom)
+            (not (not-robot-at ?cto))
+            (robot-at ?cto)
+            (increase (total-cost) (move-robot-cost))
+        )
+)
+
+(:action move-east
+    :parameters (?cfrom - card ?xfrom - gridpos ?yfrom - gridpos ?dfrom - directionH ?cto - card ?xto - gridpos ?yto - gridpos ?dto - directionH)
+    :precondition
+        (and
+            (not-cards-moving)
+            (= ?dfrom e)
+            (robot-at ?cfrom)
+            (card-at ?cfrom ?xfrom ?yfrom)
+            (card-at ?cto ?xto ?yto)
+            (next ?xto ?xfrom)
+            (= ?yfrom ?yto)
+            (not (= ?dfrom ?dto))
+            (not-blocked ?cfrom ?dfrom)
+            (not-blocked ?cto ?dto)
+        )
+    :effect
+        (and
+            (not (robot-at ?cfrom))
+            (not-robot-at ?cfrom)
+            (not (not-robot-at ?cto))
+            (robot-at ?cto)
+            (increase (total-cost) (move-robot-cost))
+        )
+)
+
+(:action move-north
+    :parameters (?cfrom - card ?xfrom - gridpos ?yfrom - gridpos ?dfrom - directionV ?cto - card ?xto - gridpos ?yto - gridpos ?dto - directionV)
+    :precondition
+        (and
+            (not-cards-moving)
+            (= ?dfrom n)
+            (robot-at ?cfrom)
+            (card-at ?cfrom ?xfrom ?yfrom)
+            (card-at ?cto ?xto ?yto)
+            (next ?yfrom ?yto)
+            (= ?xfrom ?xto)
+            (not (= ?dfrom ?dto))
+            (not-blocked ?cfrom ?dfrom)
+            (not-blocked ?cto ?dto)
+        )
+    :effect
+        (and
+            (not (robot-at ?cfrom))
+            (not-robot-at ?cfrom)
+            (not (not-robot-at ?cto))
+            (robot-at ?cto)
+            (increase (total-cost) (move-robot-cost))
+        )
+)
+
+(:action move-south
+    :parameters (?cfrom - card ?xfrom - gridpos ?yfrom - gridpos ?dfrom - directionV ?cto - card ?xto - gridpos ?yto - gridpos ?dto - directionV)
+    :precondition
+        (and
+            (not-cards-moving)
+            (= ?dfrom s)
+            (robot-at ?cfrom)
+            (card-at ?cfrom ?xfrom ?yfrom)
+            (card-at ?cto ?xto ?yto)
+            (next ?yto ?yfrom)
+            (= ?xfrom ?xto)
+            (not (= ?dfrom ?dto))
+            (not-blocked ?cfrom ?dfrom)
+            (not-blocked ?cto ?dto)
+        )
+    :effect
+        (and
+            (not (robot-at ?cfrom))
+            (not-robot-at ?cfrom)
+            (not (not-robot-at ?cto))
+            (robot-at ?cto)
+            (increase (total-cost) (move-robot-cost))
+        )
+)
+
+
+;; there 3 (start, move, stop) for each direction to rotate the cards
+;; rotating ends in a deadend if the card with the robot in the row/column that is rotated
+;; ----------------------------------------------------------------------------------------
+
+;; starts rotation
+;; saves the card with the minimal index
+;; determines which card should be updated next the corresponding move action
+;; and makes all other actions inapplicable by setting cards-moving and cards-moving-west
+(:action start-move-card-west
+:parameters(?cm - card ?x - gridpos ?y - gridpos ?cnext - card ?nextx - gridpos)
+:precondition
+    (and
+        (not-cards-moving)
+        (not-robot-at ?cm)
+        (card-at ?cm ?x ?y )
+        (min-pos ?x)
+        (card-at ?cnext ?nextx ?y)
+        (next ?nextx ?x)
+    )
+:effect
+    (and
+        (cards-moving)
+        (cards-moving-west)
+        (not (not-cards-moving))
+        (not (card-at ?cm ?x ?y ))
+        (new-headtail-card ?cm)
+        (next-moving-card ?cnext)
+        (increase (total-cost) (move-card))
+    )
+)
+
+;; updates the grid column index of ?cm which is the next card to update
+(:action move-card-west
+:parameters(?cm - card ?x - gridpos ?y - gridpos ?cnext - card ?nextx - gridpos ?prevx - gridpos)
+:precondition
+    (and
+        (cards-moving)
+        (cards-moving-west)
+        (not-robot-at ?cm)
+        (next-moving-card ?cm)
+        (card-at ?cm ?x ?y )
+        (card-at ?cnext ?nextx ?y)
+        (next ?x ?prevx)
+        (next ?nextx ?x)
+    )
+:effect
+    (and
+        (cards-moving)
+        (cards-moving-west)
+        (not (card-at ?cm ?x ?y))
+        (card-at ?cm ?prevx ?y)
+        (not (next-moving-card ?cm))
+        (next-moving-card ?cnext)
+    )
+)
+
+;; stops rotation
+;; updates the grid index of the card specified by the start move action in new-headtail-card
+(:action stop-move-card-west
+:parameters(?cm - card ?x - gridpos ?y - gridpos ?prevx - gridpos ?newtc - card)
+:precondition
+    (and
+        (cards-moving)
+        (cards-moving-west)
+        (not-robot-at ?cm)
+        (next-moving-card ?cm)
+        (card-at ?cm ?x ?y )
+        (next ?x ?prevx)
+        (max-pos ?x)
+        (new-headtail-card ?newtc)
+    )
+:effect
+    (and
+        (not-cards-moving)
+        (not (cards-moving))
+        (not (cards-moving-west))
+        (not (card-at ?cm ?x ?y))
+        (card-at ?cm ?prevx ?y)
+        (card-at ?newtc ?x ?y)
+        (not (new-headtail-card ?newtc))
+        (not (next-moving-card ?cm))
+    )
+)
+
+
+;; ----------------------------------------------------------------------------------------
+
+(:action start-move-card-east
+:parameters(?cm - card ?x - gridpos ?y - gridpos ?cnext - card ?nextx - gridpos)
+:precondition
+    (and
+        (not-cards-moving)
+        (not-robot-at ?cm)
+        (card-at ?cm ?x ?y )
+        (max-pos ?x)
+        (card-at ?cnext ?nextx ?y)
+        (next ?x ?nextx)
+    )
+:effect
+    (and
+        (not (not-cards-moving))
+        (cards-moving)
+        (cards-moving-east)
+        (not (card-at ?cm ?x ?y ))
+        (new-headtail-card ?cm)
+        (next-moving-card ?cnext)
+        (increase (total-cost) (move-card))
+    )
+)
+
+(:action move-card-east
+:parameters(?cm - card ?x - gridpos ?y - gridpos ?cnext - card ?nextx - gridpos ?prevx - gridpos)
+:precondition
+    (and
+        (cards-moving)
+        (cards-moving-east)
+        (not-robot-at ?cm)
+        (next-moving-card ?cm)
+        (card-at ?cm ?x ?y )
+        (card-at ?cnext ?nextx ?y)
+        (next ?prevx ?x)
+        (next ?x ?nextx)
+    )
+:effect
+    (and
+        (cards-moving)
+        (cards-moving-east)
+        (not (card-at ?cm ?x ?y))
+        (card-at ?cm ?prevx ?y)
+        (not (next-moving-card ?cm))
+        (next-moving-card ?cnext)
+    )
+)
+
+(:action stop-move-card-east
+:parameters(?cm - card ?x - gridpos ?y - gridpos ?prevx - gridpos ?newtc - card)
+:precondition
+    (and
+        (cards-moving)
+        (cards-moving-east)
+        (not-robot-at ?cm)
+        (next-moving-card ?cm)
+        (card-at ?cm ?x ?y )
+        (next  ?prevx ?x)
+        (min-pos ?x)
+        (new-headtail-card ?newtc)
+    )
+:effect
+    (and
+        (not-cards-moving)
+        (not (cards-moving))
+        (not (cards-moving-east))
+        (not (card-at ?cm ?x ?y))
+        (card-at ?cm ?prevx ?y)
+        (card-at ?newtc ?x ?y)
+        (not (new-headtail-card ?newtc))
+        (not (next-moving-card ?cm))
+    )
+)
+
+;; ----------------------------------------------------------------------------------------
+
+(:action start-move-card-north
+:parameters(?cm - card ?x - gridpos ?y - gridpos ?cnext - card ?nexty - gridpos)
+:precondition
+    (and
+        (not-cards-moving)
+        (not-robot-at ?cm)
+        (card-at ?cm ?x ?y )
+        (min-pos ?y)
+        (card-at ?cnext ?x ?nexty)
+        (next ?nexty ?y)
+    )
+:effect
+    (and
+        (not (not-cards-moving))
+        (cards-moving)
+        (cards-moving-north)
+        (not (card-at ?cm ?x ?y ))
+        (new-headtail-card ?cm)
+        (next-moving-card ?cnext)
+        (increase (total-cost) (move-card))
+    )
+)
+
+(:action move-card-north
+:parameters(?cm - card ?x - gridpos ?y - gridpos  ?cnext - card ?nexty - gridpos ?prevy - gridpos)
+:precondition
+    (and
+        (cards-moving)
+        (cards-moving-north)
+        (not-robot-at ?cm)
+        (next-moving-card ?cm)
+        (card-at ?cm ?x ?y )
+        (card-at ?cnext ?x ?nexty)
+        (next ?y ?prevy)
+        (next ?nexty ?y)
+    )
+:effect
+    (and
+        (cards-moving)
+        (cards-moving-north)
+        (not (card-at ?cm ?x ?y))
+        (card-at ?cm ?x ?prevy)
+        (not (next-moving-card ?cm))
+        (next-moving-card ?cnext)
+    )
+)
+
+(:action stop-move-card-north
+:parameters(?cm - card ?x - gridpos ?y - gridpos ?prevy - gridpos ?newtc - card)
+:precondition
+    (and
+        (cards-moving)
+        (cards-moving-north)
+        (not-robot-at ?cm)
+        (next-moving-card ?cm)
+        (card-at ?cm ?x ?y )
+        (next ?y ?prevy)
+        (max-pos ?y)
+        (new-headtail-card ?newtc)
+    )
+:effect
+    (and
+        (not-cards-moving)
+        (not (cards-moving))
+        (not (cards-moving-north))
+        (not (card-at ?cm ?x ?y))
+        (card-at ?cm ?x ?prevy)
+        (card-at ?newtc ?x ?y)
+        (not (new-headtail-card ?newtc))
+        (not (next-moving-card ?cm))
+    )
+)
+
+;; ----------------------------------------------------------------------------------------
+
+(:action start-move-card-south
+:parameters(?cm - card ?x - gridpos ?y - gridpos  ?cnext - card ?nexty - gridpos)
+:precondition
+    (and
+        (not-cards-moving)
+        (not-robot-at ?cm)
+        (card-at ?cm ?x ?y )
+        (max-pos ?y)
+        (card-at ?cnext ?x ?nexty)
+        (next ?y ?nexty)
+    )
+:effect
+    (and
+        (cards-moving)
+        (cards-moving-south)
+        (not (not-cards-moving))
+        (not (card-at ?cm ?x ?y ))
+        (new-headtail-card ?cm)
+        (next-moving-card ?cnext)
+        (increase (total-cost) (move-card))
+    )
+)
+
+(:action move-card-south
+:parameters(?cm - card ?x - gridpos ?y - gridpos  ?cnext - card ?nexty - gridpos ?prevy - gridpos)
+:precondition
+    (and
+        (cards-moving)
+        (cards-moving-south)
+        (not-robot-at ?cm)
+        (next-moving-card ?cm)
+        (card-at ?cm ?x ?y )
+        (card-at ?cnext ?x ?nexty)
+        (next ?prevy ?y)
+        (next ?y ?nexty)
+    )
+:effect
+    (and
+        (cards-moving)
+        (cards-moving-south)
+        (not (card-at ?cm ?x ?y))
+        (card-at ?cm ?x ?prevy)
+        (not (next-moving-card ?cm))
+        (next-moving-card ?cnext)
+    )
+)
+
+(:action stop-move-card-south
+:parameters(?cm - card ?x - gridpos ?y - gridpos ?prevy - gridpos ?newtc - card)
+:precondition
+    (and
+        (cards-moving)
+        (cards-moving-south)
+        (not-robot-at ?cm)
+        (next-moving-card ?cm)
+        (card-at ?cm ?x ?y )
+        (next ?prevy ?y)
+        (min-pos ?y)
+        (new-headtail-card ?newtc)
+    )
+:effect
+    (and
+        (not-cards-moving)
+        (not (cards-moving))
+        (not (cards-moving-south))
+        (not (card-at ?cm ?x ?y))
+        (card-at ?cm ?x ?prevy)
+        (card-at ?newtc ?x ?y)
+        (not (new-headtail-card ?newtc))
+        (not (next-moving-card ?cm))
+    )
+)
+
+
+;; checks whether the robot can leave the labyrinth i.e
+;; whether the card the robot is currently on is in the bottom right corner
+;; and the rover is in sector SE
+(:action leave
+:parameters(?c - card ?prow - gridpos ?pcolumn - gridpos)
+:precondition
+    (and
+        (not-cards-moving)
+        (robot-at ?c)
+        (card-at ?c ?prow ?pcolumn)
+        (max-pos ?prow)
+        (max-pos ?pcolumn)
+        (not-blocked ?c s )
+    )
+:effect
+    (and
+        (left)
+    )
+)
+)
+

--- a/labyrinth/SAT/p01.pddl
+++ b/labyrinth/SAT/p01.pddl
@@ -1,0 +1,231 @@
+;; Generated with seed: 1229, size: 5, num-rotations: 1
+(define (problem labyrinth-size-5-rotations-1-seed-1229)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24  - card
+)
+(:init
+	(NOT-BLOCKED card24 S)
+	(NOT-BLOCKED card24 E)
+	(NOT-BLOCKED card24 N)
+
+	(NOT-BLOCKED card23 W)
+	(NOT-BLOCKED card23 N)
+
+	(NOT-BLOCKED card22 W)
+	(NOT-BLOCKED card22 S)
+
+	(NOT-BLOCKED card21 W)
+	(NOT-BLOCKED card21 S)
+
+	(NOT-BLOCKED card20 S)
+	(NOT-BLOCKED card20 E)
+	(NOT-BLOCKED card20 N)
+
+	(NOT-BLOCKED card19 S)
+	(NOT-BLOCKED card19 E)
+	(NOT-BLOCKED card19 N)
+
+	(NOT-BLOCKED card18 E)
+	(NOT-BLOCKED card18 N)
+
+	(NOT-BLOCKED card17 W)
+	(NOT-BLOCKED card17 E)
+
+	(NOT-BLOCKED card16 W)
+	(NOT-BLOCKED card16 S)
+
+	(NOT-BLOCKED card15 W)
+	(NOT-BLOCKED card15 N)
+
+	(NOT-BLOCKED card14 W)
+	(NOT-BLOCKED card14 S)
+
+	(NOT-BLOCKED card13 E)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 S)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 W)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 W)
+	(NOT-BLOCKED card10 S)
+	(NOT-BLOCKED card10 E)
+
+	(NOT-BLOCKED card9 W)
+	(NOT-BLOCKED card9 N)
+
+	(NOT-BLOCKED card8 S)
+	(NOT-BLOCKED card8 E)
+
+	(NOT-BLOCKED card7 W)
+	(NOT-BLOCKED card7 E)
+
+	(NOT-BLOCKED card6 S)
+	(NOT-BLOCKED card6 E)
+	(NOT-BLOCKED card6 N)
+
+	(NOT-BLOCKED card5 E)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 S)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 E)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 S)
+	(NOT-BLOCKED card2 E)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 E)
+
+	(NOT-BLOCKED card0 E)
+	(NOT-BLOCKED card0 N)
+
+	(MAX-POS pos4)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card5 pos0 pos1)
+	(card-at card6 pos1 pos1)
+	(card-at card7 pos2 pos1)
+	(card-at card8 pos3 pos1)
+	(card-at card9 pos4 pos1)
+	(card-at card11 pos0 pos2)
+	(card-at card12 pos1 pos2)
+	(card-at card13 pos2 pos2)
+	(card-at card14 pos3 pos2)
+	(card-at card10 pos4 pos2)
+	(card-at card15 pos0 pos3)
+	(card-at card16 pos1 pos3)
+	(card-at card17 pos2 pos3)
+	(card-at card18 pos3 pos3)
+	(card-at card19 pos4 pos3)
+	(card-at card20 pos0 pos4)
+	(card-at card21 pos1 pos4)
+	(card-at card22 pos2 pos4)
+	(card-at card23 pos3 pos4)
+	(card-at card24 pos4 pos4)
+
+	(BLOCKED card0 S)
+	(BLOCKED card0 W)
+
+	(BLOCKED card1 N)
+	(BLOCKED card1 S)
+
+	(BLOCKED card2 N)
+
+	(BLOCKED card3 N)
+	(BLOCKED card3 S)
+
+	(BLOCKED card4 N)
+	(BLOCKED card4 E)
+
+	(BLOCKED card5 S)
+	(BLOCKED card5 W)
+
+	(BLOCKED card6 W)
+
+	(BLOCKED card7 N)
+	(BLOCKED card7 S)
+
+	(BLOCKED card8 N)
+	(BLOCKED card8 W)
+
+	(BLOCKED card9 E)
+	(BLOCKED card9 S)
+
+	(BLOCKED card11 E)
+	(BLOCKED card11 S)
+
+	(BLOCKED card12 E)
+	(BLOCKED card12 W)
+
+	(BLOCKED card13 S)
+	(BLOCKED card13 W)
+
+	(BLOCKED card14 N)
+	(BLOCKED card14 E)
+
+	(BLOCKED card10 N)
+
+	(BLOCKED card15 E)
+	(BLOCKED card15 S)
+
+	(BLOCKED card16 N)
+	(BLOCKED card16 E)
+
+	(BLOCKED card17 N)
+	(BLOCKED card17 S)
+
+	(BLOCKED card18 S)
+	(BLOCKED card18 W)
+
+	(BLOCKED card19 W)
+
+	(BLOCKED card20 W)
+
+	(BLOCKED card21 N)
+	(BLOCKED card21 E)
+
+	(BLOCKED card22 N)
+	(BLOCKED card22 E)
+
+	(BLOCKED card23 E)
+	(BLOCKED card23 S)
+
+	(BLOCKED card24 W)
+
+
+	(robot-at card0)
+
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/SAT/p02.pddl
+++ b/labyrinth/SAT/p02.pddl
@@ -1,0 +1,231 @@
+;; Generated with seed: 1231, size: 5, num-rotations: 2
+(define (problem labyrinth-size-5-rotations-2-seed-1231)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24  - card
+)
+(:init
+	(NOT-BLOCKED card24 W)
+	(NOT-BLOCKED card24 S)
+
+	(NOT-BLOCKED card23 W)
+	(NOT-BLOCKED card23 E)
+	(NOT-BLOCKED card23 N)
+
+	(NOT-BLOCKED card22 E)
+	(NOT-BLOCKED card22 N)
+
+	(NOT-BLOCKED card21 S)
+	(NOT-BLOCKED card21 E)
+
+	(NOT-BLOCKED card20 E)
+	(NOT-BLOCKED card20 N)
+
+	(NOT-BLOCKED card19 W)
+	(NOT-BLOCKED card19 S)
+	(NOT-BLOCKED card19 E)
+	(NOT-BLOCKED card19 N)
+
+	(NOT-BLOCKED card18 W)
+	(NOT-BLOCKED card18 E)
+
+	(NOT-BLOCKED card17 W)
+	(NOT-BLOCKED card17 S)
+	(NOT-BLOCKED card17 E)
+
+	(NOT-BLOCKED card16 W)
+	(NOT-BLOCKED card16 S)
+
+	(NOT-BLOCKED card15 S)
+	(NOT-BLOCKED card15 E)
+
+	(NOT-BLOCKED card14 S)
+	(NOT-BLOCKED card14 E)
+	(NOT-BLOCKED card14 N)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 E)
+
+	(NOT-BLOCKED card12 S)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 E)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 S)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 W)
+	(NOT-BLOCKED card9 S)
+	(NOT-BLOCKED card9 E)
+
+	(NOT-BLOCKED card8 E)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 W)
+	(NOT-BLOCKED card7 E)
+
+	(NOT-BLOCKED card6 S)
+	(NOT-BLOCKED card6 E)
+
+	(NOT-BLOCKED card5 W)
+	(NOT-BLOCKED card5 S)
+	(NOT-BLOCKED card5 E)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 S)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 S)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 E)
+	(NOT-BLOCKED card2 N)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 E)
+
+	(NOT-BLOCKED card0 S)
+	(NOT-BLOCKED card0 E)
+
+	(MAX-POS pos4)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card5 pos0 pos1)
+	(card-at card6 pos1 pos1)
+	(card-at card7 pos2 pos1)
+	(card-at card8 pos3 pos1)
+	(card-at card9 pos4 pos1)
+	(card-at card14 pos0 pos2)
+	(card-at card10 pos1 pos2)
+	(card-at card11 pos2 pos2)
+	(card-at card12 pos3 pos2)
+	(card-at card13 pos4 pos2)
+	(card-at card19 pos0 pos3)
+	(card-at card15 pos1 pos3)
+	(card-at card16 pos2 pos3)
+	(card-at card17 pos3 pos3)
+	(card-at card18 pos4 pos3)
+	(card-at card20 pos0 pos4)
+	(card-at card21 pos1 pos4)
+	(card-at card22 pos2 pos4)
+	(card-at card23 pos3 pos4)
+	(card-at card24 pos4 pos4)
+
+	(BLOCKED card0 N)
+	(BLOCKED card0 W)
+
+	(BLOCKED card1 N)
+	(BLOCKED card1 S)
+
+	(BLOCKED card2 S)
+
+	(BLOCKED card3 N)
+	(BLOCKED card3 E)
+
+	(BLOCKED card4 N)
+	(BLOCKED card4 E)
+
+	(BLOCKED card5 N)
+
+	(BLOCKED card6 N)
+	(BLOCKED card6 W)
+
+	(BLOCKED card7 N)
+	(BLOCKED card7 S)
+
+	(BLOCKED card8 S)
+	(BLOCKED card8 W)
+
+	(BLOCKED card9 N)
+
+	(BLOCKED card14 W)
+
+	(BLOCKED card10 E)
+	(BLOCKED card10 W)
+
+	(BLOCKED card11 S)
+	(BLOCKED card11 W)
+
+	(BLOCKED card12 E)
+	(BLOCKED card12 W)
+
+	(BLOCKED card13 N)
+	(BLOCKED card13 S)
+
+
+	(BLOCKED card15 N)
+	(BLOCKED card15 W)
+
+	(BLOCKED card16 N)
+	(BLOCKED card16 E)
+
+	(BLOCKED card17 N)
+
+	(BLOCKED card18 N)
+	(BLOCKED card18 S)
+
+	(BLOCKED card20 S)
+	(BLOCKED card20 W)
+
+	(BLOCKED card21 N)
+	(BLOCKED card21 W)
+
+	(BLOCKED card22 S)
+	(BLOCKED card22 W)
+
+	(BLOCKED card23 S)
+
+	(BLOCKED card24 N)
+	(BLOCKED card24 E)
+
+
+	(robot-at card0)
+
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/SAT/p03.pddl
+++ b/labyrinth/SAT/p03.pddl
@@ -1,0 +1,231 @@
+;; Generated with seed: 1237, size: 5, num-rotations: 3
+(define (problem labyrinth-size-5-rotations-3-seed-1237)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24  - card
+)
+(:init
+	(NOT-BLOCKED card24 W)
+	(NOT-BLOCKED card24 S)
+
+	(NOT-BLOCKED card23 E)
+	(NOT-BLOCKED card23 N)
+
+	(NOT-BLOCKED card22 S)
+	(NOT-BLOCKED card22 N)
+
+	(NOT-BLOCKED card21 S)
+	(NOT-BLOCKED card21 N)
+
+	(NOT-BLOCKED card20 E)
+	(NOT-BLOCKED card20 N)
+
+	(NOT-BLOCKED card19 S)
+	(NOT-BLOCKED card19 E)
+
+	(NOT-BLOCKED card18 S)
+	(NOT-BLOCKED card18 N)
+
+	(NOT-BLOCKED card17 S)
+	(NOT-BLOCKED card17 E)
+
+	(NOT-BLOCKED card16 W)
+	(NOT-BLOCKED card16 E)
+	(NOT-BLOCKED card16 N)
+
+	(NOT-BLOCKED card15 W)
+	(NOT-BLOCKED card15 N)
+
+	(NOT-BLOCKED card14 S)
+	(NOT-BLOCKED card14 N)
+
+	(NOT-BLOCKED card13 S)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 E)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 W)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 W)
+	(NOT-BLOCKED card10 E)
+
+	(NOT-BLOCKED card9 W)
+	(NOT-BLOCKED card9 S)
+	(NOT-BLOCKED card9 N)
+
+	(NOT-BLOCKED card8 S)
+	(NOT-BLOCKED card8 E)
+
+	(NOT-BLOCKED card7 W)
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 S)
+	(NOT-BLOCKED card6 N)
+
+	(NOT-BLOCKED card5 S)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 S)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 E)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 E)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 E)
+	(NOT-BLOCKED card1 N)
+
+	(NOT-BLOCKED card0 W)
+	(NOT-BLOCKED card0 E)
+
+	(MAX-POS pos4)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card23 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card5 pos0 pos1)
+	(card-at card6 pos1 pos1)
+	(card-at card7 pos2 pos1)
+	(card-at card3 pos3 pos1)
+	(card-at card9 pos4 pos1)
+	(card-at card10 pos0 pos2)
+	(card-at card11 pos1 pos2)
+	(card-at card12 pos2 pos2)
+	(card-at card8 pos3 pos2)
+	(card-at card14 pos4 pos2)
+	(card-at card18 pos0 pos3)
+	(card-at card19 pos1 pos3)
+	(card-at card15 pos2 pos3)
+	(card-at card13 pos3 pos3)
+	(card-at card17 pos4 pos3)
+	(card-at card20 pos0 pos4)
+	(card-at card21 pos1 pos4)
+	(card-at card22 pos2 pos4)
+	(card-at card16 pos3 pos4)
+	(card-at card24 pos4 pos4)
+
+	(BLOCKED card0 N)
+	(BLOCKED card0 S)
+
+	(BLOCKED card1 S)
+
+	(BLOCKED card2 N)
+	(BLOCKED card2 S)
+
+	(BLOCKED card23 S)
+	(BLOCKED card23 W)
+
+	(BLOCKED card4 N)
+	(BLOCKED card4 E)
+
+	(BLOCKED card5 E)
+	(BLOCKED card5 W)
+
+	(BLOCKED card6 E)
+	(BLOCKED card6 W)
+
+	(BLOCKED card7 E)
+
+	(BLOCKED card3 N)
+	(BLOCKED card3 S)
+
+	(BLOCKED card9 E)
+
+	(BLOCKED card10 N)
+	(BLOCKED card10 S)
+
+	(BLOCKED card11 E)
+	(BLOCKED card11 S)
+
+	(BLOCKED card12 S)
+	(BLOCKED card12 W)
+
+	(BLOCKED card8 N)
+	(BLOCKED card8 W)
+
+	(BLOCKED card14 E)
+	(BLOCKED card14 W)
+
+	(BLOCKED card18 E)
+	(BLOCKED card18 W)
+
+	(BLOCKED card19 N)
+	(BLOCKED card19 W)
+
+	(BLOCKED card15 E)
+	(BLOCKED card15 S)
+
+	(BLOCKED card13 E)
+	(BLOCKED card13 W)
+
+	(BLOCKED card17 N)
+	(BLOCKED card17 W)
+
+	(BLOCKED card20 S)
+	(BLOCKED card20 W)
+
+	(BLOCKED card21 E)
+	(BLOCKED card21 W)
+
+	(BLOCKED card22 E)
+	(BLOCKED card22 W)
+
+	(BLOCKED card16 S)
+
+	(BLOCKED card24 N)
+	(BLOCKED card24 E)
+
+
+	(robot-at card0)
+
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/SAT/p04.pddl
+++ b/labyrinth/SAT/p04.pddl
@@ -1,0 +1,231 @@
+;; Generated with seed: 1249, size: 5, num-rotations: 4
+(define (problem labyrinth-size-5-rotations-4-seed-1249)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24  - card
+)
+(:init
+	(NOT-BLOCKED card24 W)
+	(NOT-BLOCKED card24 S)
+	(NOT-BLOCKED card24 E)
+	(NOT-BLOCKED card24 N)
+
+	(NOT-BLOCKED card23 W)
+	(NOT-BLOCKED card23 E)
+	(NOT-BLOCKED card23 N)
+
+	(NOT-BLOCKED card22 S)
+	(NOT-BLOCKED card22 E)
+
+	(NOT-BLOCKED card21 E)
+	(NOT-BLOCKED card21 N)
+
+	(NOT-BLOCKED card20 W)
+	(NOT-BLOCKED card20 E)
+	(NOT-BLOCKED card20 N)
+
+	(NOT-BLOCKED card19 E)
+	(NOT-BLOCKED card19 N)
+
+	(NOT-BLOCKED card18 S)
+	(NOT-BLOCKED card18 N)
+
+	(NOT-BLOCKED card17 S)
+	(NOT-BLOCKED card17 E)
+
+	(NOT-BLOCKED card16 W)
+	(NOT-BLOCKED card16 N)
+
+	(NOT-BLOCKED card15 E)
+	(NOT-BLOCKED card15 N)
+
+	(NOT-BLOCKED card14 S)
+	(NOT-BLOCKED card14 E)
+
+	(NOT-BLOCKED card13 S)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 W)
+	(NOT-BLOCKED card12 S)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 W)
+	(NOT-BLOCKED card11 S)
+	(NOT-BLOCKED card11 E)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 W)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 E)
+	(NOT-BLOCKED card9 N)
+
+	(NOT-BLOCKED card8 W)
+	(NOT-BLOCKED card8 S)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 W)
+	(NOT-BLOCKED card7 E)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 E)
+	(NOT-BLOCKED card6 N)
+
+	(NOT-BLOCKED card5 S)
+	(NOT-BLOCKED card5 E)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 N)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 S)
+	(NOT-BLOCKED card3 E)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 E)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 S)
+
+	(NOT-BLOCKED card0 S)
+	(NOT-BLOCKED card0 E)
+
+	(MAX-POS pos4)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card9 pos0 pos1)
+	(card-at card5 pos1 pos1)
+	(card-at card6 pos2 pos1)
+	(card-at card7 pos3 pos1)
+	(card-at card8 pos4 pos1)
+	(card-at card14 pos0 pos2)
+	(card-at card10 pos1 pos2)
+	(card-at card11 pos2 pos2)
+	(card-at card12 pos3 pos2)
+	(card-at card13 pos4 pos2)
+	(card-at card15 pos0 pos3)
+	(card-at card16 pos1 pos3)
+	(card-at card17 pos2 pos3)
+	(card-at card18 pos3 pos3)
+	(card-at card19 pos4 pos3)
+	(card-at card20 pos0 pos4)
+	(card-at card21 pos1 pos4)
+	(card-at card22 pos2 pos4)
+	(card-at card23 pos3 pos4)
+	(card-at card24 pos4 pos4)
+
+	(BLOCKED card0 N)
+	(BLOCKED card0 W)
+
+	(BLOCKED card1 N)
+	(BLOCKED card1 E)
+
+	(BLOCKED card2 N)
+	(BLOCKED card2 S)
+
+	(BLOCKED card3 N)
+
+	(BLOCKED card4 E)
+	(BLOCKED card4 S)
+
+	(BLOCKED card9 S)
+	(BLOCKED card9 W)
+
+	(BLOCKED card5 W)
+
+	(BLOCKED card6 S)
+	(BLOCKED card6 W)
+
+	(BLOCKED card7 S)
+
+	(BLOCKED card8 E)
+
+	(BLOCKED card14 N)
+	(BLOCKED card14 W)
+
+	(BLOCKED card10 E)
+	(BLOCKED card10 S)
+
+
+	(BLOCKED card12 E)
+
+	(BLOCKED card13 E)
+	(BLOCKED card13 W)
+
+	(BLOCKED card15 S)
+	(BLOCKED card15 W)
+
+	(BLOCKED card16 E)
+	(BLOCKED card16 S)
+
+	(BLOCKED card17 N)
+	(BLOCKED card17 W)
+
+	(BLOCKED card18 E)
+	(BLOCKED card18 W)
+
+	(BLOCKED card19 S)
+	(BLOCKED card19 W)
+
+	(BLOCKED card20 S)
+
+	(BLOCKED card21 S)
+	(BLOCKED card21 W)
+
+	(BLOCKED card22 N)
+	(BLOCKED card22 W)
+
+	(BLOCKED card23 S)
+
+
+
+	(robot-at card0)
+
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/SAT/p05.pddl
+++ b/labyrinth/SAT/p05.pddl
@@ -1,0 +1,320 @@
+;; Generated with seed: 1259, size: 6, num-rotations: 1
+(define (problem labyrinth-size-6-rotations-1-seed-1259)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35  - card
+)
+(:init
+	(NOT-BLOCKED card35 S)
+	(NOT-BLOCKED card35 E)
+	(NOT-BLOCKED card35 N)
+
+	(NOT-BLOCKED card34 W)
+	(NOT-BLOCKED card34 N)
+
+	(NOT-BLOCKED card33 W)
+	(NOT-BLOCKED card33 S)
+
+	(NOT-BLOCKED card32 W)
+	(NOT-BLOCKED card32 E)
+	(NOT-BLOCKED card32 N)
+
+	(NOT-BLOCKED card31 W)
+	(NOT-BLOCKED card31 S)
+	(NOT-BLOCKED card31 N)
+
+	(NOT-BLOCKED card30 W)
+	(NOT-BLOCKED card30 S)
+	(NOT-BLOCKED card30 N)
+
+	(NOT-BLOCKED card29 W)
+	(NOT-BLOCKED card29 S)
+	(NOT-BLOCKED card29 N)
+
+	(NOT-BLOCKED card28 W)
+	(NOT-BLOCKED card28 E)
+	(NOT-BLOCKED card28 N)
+
+	(NOT-BLOCKED card27 S)
+	(NOT-BLOCKED card27 E)
+	(NOT-BLOCKED card27 N)
+
+	(NOT-BLOCKED card26 W)
+	(NOT-BLOCKED card26 S)
+	(NOT-BLOCKED card26 E)
+
+	(NOT-BLOCKED card25 W)
+	(NOT-BLOCKED card25 N)
+
+	(NOT-BLOCKED card24 W)
+	(NOT-BLOCKED card24 S)
+
+	(NOT-BLOCKED card23 W)
+	(NOT-BLOCKED card23 S)
+
+	(NOT-BLOCKED card22 W)
+	(NOT-BLOCKED card22 S)
+	(NOT-BLOCKED card22 N)
+
+	(NOT-BLOCKED card21 S)
+	(NOT-BLOCKED card21 E)
+	(NOT-BLOCKED card21 N)
+
+	(NOT-BLOCKED card20 W)
+	(NOT-BLOCKED card20 S)
+
+	(NOT-BLOCKED card19 W)
+	(NOT-BLOCKED card19 S)
+	(NOT-BLOCKED card19 E)
+
+	(NOT-BLOCKED card18 W)
+	(NOT-BLOCKED card18 S)
+
+	(NOT-BLOCKED card17 E)
+	(NOT-BLOCKED card17 N)
+
+	(NOT-BLOCKED card16 W)
+	(NOT-BLOCKED card16 S)
+	(NOT-BLOCKED card16 N)
+
+	(NOT-BLOCKED card15 W)
+	(NOT-BLOCKED card15 E)
+	(NOT-BLOCKED card15 N)
+
+	(NOT-BLOCKED card14 W)
+	(NOT-BLOCKED card14 S)
+	(NOT-BLOCKED card14 E)
+	(NOT-BLOCKED card14 N)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 E)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 S)
+	(NOT-BLOCKED card11 E)
+
+	(NOT-BLOCKED card10 W)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 W)
+	(NOT-BLOCKED card9 S)
+
+	(NOT-BLOCKED card8 W)
+	(NOT-BLOCKED card8 S)
+	(NOT-BLOCKED card8 E)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 E)
+
+	(NOT-BLOCKED card6 W)
+	(NOT-BLOCKED card6 S)
+	(NOT-BLOCKED card6 N)
+
+	(NOT-BLOCKED card5 W)
+	(NOT-BLOCKED card5 S)
+
+	(NOT-BLOCKED card4 E)
+	(NOT-BLOCKED card4 N)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 S)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 E)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 N)
+
+	(NOT-BLOCKED card0 S)
+	(NOT-BLOCKED card0 E)
+
+	(MAX-POS pos5)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card5 pos5 pos0)
+	(card-at card7 pos0 pos1)
+	(card-at card8 pos1 pos1)
+	(card-at card9 pos2 pos1)
+	(card-at card10 pos3 pos1)
+	(card-at card11 pos4 pos1)
+	(card-at card6 pos5 pos1)
+	(card-at card12 pos0 pos2)
+	(card-at card13 pos1 pos2)
+	(card-at card14 pos2 pos2)
+	(card-at card15 pos3 pos2)
+	(card-at card16 pos4 pos2)
+	(card-at card17 pos5 pos2)
+	(card-at card18 pos0 pos3)
+	(card-at card19 pos1 pos3)
+	(card-at card20 pos2 pos3)
+	(card-at card21 pos3 pos3)
+	(card-at card22 pos4 pos3)
+	(card-at card23 pos5 pos3)
+	(card-at card24 pos0 pos4)
+	(card-at card25 pos1 pos4)
+	(card-at card26 pos2 pos4)
+	(card-at card27 pos3 pos4)
+	(card-at card28 pos4 pos4)
+	(card-at card29 pos5 pos4)
+	(card-at card30 pos0 pos5)
+	(card-at card31 pos1 pos5)
+	(card-at card32 pos2 pos5)
+	(card-at card33 pos3 pos5)
+	(card-at card34 pos4 pos5)
+	(card-at card35 pos5 pos5)
+
+	(BLOCKED card0 N)
+	(BLOCKED card0 W)
+
+	(BLOCKED card1 E)
+	(BLOCKED card1 S)
+
+	(BLOCKED card2 N)
+	(BLOCKED card2 S)
+
+	(BLOCKED card3 N)
+	(BLOCKED card3 E)
+
+	(BLOCKED card4 S)
+	(BLOCKED card4 W)
+
+	(BLOCKED card5 N)
+	(BLOCKED card5 E)
+
+	(BLOCKED card7 N)
+	(BLOCKED card7 W)
+
+
+	(BLOCKED card9 N)
+	(BLOCKED card9 E)
+
+	(BLOCKED card10 E)
+	(BLOCKED card10 S)
+
+	(BLOCKED card11 N)
+	(BLOCKED card11 W)
+
+	(BLOCKED card6 E)
+
+	(BLOCKED card12 S)
+	(BLOCKED card12 W)
+
+	(BLOCKED card13 E)
+	(BLOCKED card13 S)
+
+
+	(BLOCKED card15 S)
+
+	(BLOCKED card16 E)
+
+	(BLOCKED card17 S)
+	(BLOCKED card17 W)
+
+	(BLOCKED card18 N)
+	(BLOCKED card18 E)
+
+	(BLOCKED card19 N)
+
+	(BLOCKED card20 N)
+	(BLOCKED card20 E)
+
+	(BLOCKED card21 W)
+
+	(BLOCKED card22 E)
+
+	(BLOCKED card23 N)
+	(BLOCKED card23 E)
+
+	(BLOCKED card24 N)
+	(BLOCKED card24 E)
+
+	(BLOCKED card25 E)
+	(BLOCKED card25 S)
+
+	(BLOCKED card26 N)
+
+	(BLOCKED card27 W)
+
+	(BLOCKED card28 S)
+
+	(BLOCKED card29 E)
+
+	(BLOCKED card30 E)
+
+	(BLOCKED card31 E)
+
+	(BLOCKED card32 S)
+
+	(BLOCKED card33 N)
+	(BLOCKED card33 E)
+
+	(BLOCKED card34 E)
+	(BLOCKED card34 S)
+
+	(BLOCKED card35 W)
+
+
+	(robot-at card0)
+
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/SAT/p06.pddl
+++ b/labyrinth/SAT/p06.pddl
@@ -1,0 +1,320 @@
+;; Generated with seed: 1277, size: 6, num-rotations: 2
+(define (problem labyrinth-size-6-rotations-2-seed-1277)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35  - card
+)
+(:init
+	(NOT-BLOCKED card35 W)
+	(NOT-BLOCKED card35 S)
+	(NOT-BLOCKED card35 N)
+
+	(NOT-BLOCKED card34 W)
+	(NOT-BLOCKED card34 S)
+	(NOT-BLOCKED card34 E)
+
+	(NOT-BLOCKED card33 W)
+	(NOT-BLOCKED card33 E)
+	(NOT-BLOCKED card33 N)
+
+	(NOT-BLOCKED card32 W)
+	(NOT-BLOCKED card32 E)
+	(NOT-BLOCKED card32 N)
+
+	(NOT-BLOCKED card31 S)
+	(NOT-BLOCKED card31 E)
+	(NOT-BLOCKED card31 N)
+
+	(NOT-BLOCKED card30 E)
+	(NOT-BLOCKED card30 N)
+
+	(NOT-BLOCKED card29 W)
+	(NOT-BLOCKED card29 N)
+
+	(NOT-BLOCKED card28 S)
+	(NOT-BLOCKED card28 E)
+	(NOT-BLOCKED card28 N)
+
+	(NOT-BLOCKED card27 W)
+	(NOT-BLOCKED card27 E)
+
+	(NOT-BLOCKED card26 W)
+	(NOT-BLOCKED card26 S)
+	(NOT-BLOCKED card26 N)
+
+	(NOT-BLOCKED card25 S)
+	(NOT-BLOCKED card25 E)
+
+	(NOT-BLOCKED card24 S)
+	(NOT-BLOCKED card24 E)
+	(NOT-BLOCKED card24 N)
+
+	(NOT-BLOCKED card23 W)
+	(NOT-BLOCKED card23 E)
+
+	(NOT-BLOCKED card22 E)
+	(NOT-BLOCKED card22 N)
+
+	(NOT-BLOCKED card21 W)
+	(NOT-BLOCKED card21 E)
+
+	(NOT-BLOCKED card20 S)
+	(NOT-BLOCKED card20 N)
+
+	(NOT-BLOCKED card19 W)
+	(NOT-BLOCKED card19 E)
+
+	(NOT-BLOCKED card18 W)
+	(NOT-BLOCKED card18 E)
+
+	(NOT-BLOCKED card17 W)
+	(NOT-BLOCKED card17 N)
+
+	(NOT-BLOCKED card16 W)
+	(NOT-BLOCKED card16 E)
+
+	(NOT-BLOCKED card15 W)
+	(NOT-BLOCKED card15 N)
+
+	(NOT-BLOCKED card14 W)
+	(NOT-BLOCKED card14 S)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 E)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 W)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 E)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 W)
+	(NOT-BLOCKED card10 S)
+	(NOT-BLOCKED card10 E)
+
+	(NOT-BLOCKED card9 W)
+	(NOT-BLOCKED card9 S)
+
+	(NOT-BLOCKED card8 E)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 W)
+	(NOT-BLOCKED card6 E)
+
+	(NOT-BLOCKED card5 W)
+	(NOT-BLOCKED card5 S)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 E)
+	(NOT-BLOCKED card4 N)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 S)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 E)
+	(NOT-BLOCKED card2 N)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 S)
+
+	(NOT-BLOCKED card0 W)
+	(NOT-BLOCKED card0 E)
+
+	(MAX-POS pos5)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+
+	(card-at card0 pos0 pos0)
+	(card-at card31 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card5 pos5 pos0)
+	(card-at card6 pos0 pos1)
+	(card-at card1 pos1 pos1)
+	(card-at card8 pos2 pos1)
+	(card-at card9 pos3 pos1)
+	(card-at card10 pos4 pos1)
+	(card-at card11 pos5 pos1)
+	(card-at card13 pos0 pos2)
+	(card-at card7 pos1 pos2)
+	(card-at card15 pos2 pos2)
+	(card-at card16 pos3 pos2)
+	(card-at card17 pos4 pos2)
+	(card-at card12 pos5 pos2)
+	(card-at card18 pos0 pos3)
+	(card-at card14 pos1 pos3)
+	(card-at card20 pos2 pos3)
+	(card-at card21 pos3 pos3)
+	(card-at card22 pos4 pos3)
+	(card-at card23 pos5 pos3)
+	(card-at card24 pos0 pos4)
+	(card-at card19 pos1 pos4)
+	(card-at card26 pos2 pos4)
+	(card-at card27 pos3 pos4)
+	(card-at card28 pos4 pos4)
+	(card-at card29 pos5 pos4)
+	(card-at card30 pos0 pos5)
+	(card-at card25 pos1 pos5)
+	(card-at card32 pos2 pos5)
+	(card-at card33 pos3 pos5)
+	(card-at card34 pos4 pos5)
+	(card-at card35 pos5 pos5)
+
+	(BLOCKED card0 N)
+	(BLOCKED card0 S)
+
+	(BLOCKED card31 W)
+
+	(BLOCKED card2 S)
+
+	(BLOCKED card3 N)
+	(BLOCKED card3 E)
+
+	(BLOCKED card4 S)
+
+	(BLOCKED card5 N)
+	(BLOCKED card5 E)
+
+	(BLOCKED card6 N)
+	(BLOCKED card6 S)
+
+	(BLOCKED card1 N)
+	(BLOCKED card1 E)
+
+	(BLOCKED card8 S)
+	(BLOCKED card8 W)
+
+	(BLOCKED card9 N)
+	(BLOCKED card9 E)
+
+	(BLOCKED card10 N)
+
+	(BLOCKED card11 S)
+	(BLOCKED card11 W)
+
+	(BLOCKED card13 S)
+
+	(BLOCKED card7 E)
+	(BLOCKED card7 W)
+
+	(BLOCKED card15 E)
+	(BLOCKED card15 S)
+
+	(BLOCKED card16 N)
+	(BLOCKED card16 S)
+
+	(BLOCKED card17 E)
+	(BLOCKED card17 S)
+
+	(BLOCKED card12 E)
+	(BLOCKED card12 S)
+
+	(BLOCKED card18 N)
+	(BLOCKED card18 S)
+
+	(BLOCKED card14 N)
+	(BLOCKED card14 E)
+
+	(BLOCKED card20 E)
+	(BLOCKED card20 W)
+
+	(BLOCKED card21 N)
+	(BLOCKED card21 S)
+
+	(BLOCKED card22 S)
+	(BLOCKED card22 W)
+
+	(BLOCKED card23 N)
+	(BLOCKED card23 S)
+
+	(BLOCKED card24 W)
+
+	(BLOCKED card19 N)
+	(BLOCKED card19 S)
+
+	(BLOCKED card26 E)
+
+	(BLOCKED card27 N)
+	(BLOCKED card27 S)
+
+	(BLOCKED card28 W)
+
+	(BLOCKED card29 E)
+	(BLOCKED card29 S)
+
+	(BLOCKED card30 S)
+	(BLOCKED card30 W)
+
+	(BLOCKED card25 N)
+	(BLOCKED card25 W)
+
+	(BLOCKED card32 S)
+
+	(BLOCKED card33 S)
+
+	(BLOCKED card34 N)
+
+	(BLOCKED card35 E)
+
+
+	(robot-at card0)
+
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/SAT/p07.pddl
+++ b/labyrinth/SAT/p07.pddl
@@ -1,0 +1,320 @@
+;; Generated with seed: 1279, size: 6, num-rotations: 3
+(define (problem labyrinth-size-6-rotations-3-seed-1279)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35  - card
+)
+(:init
+	(NOT-BLOCKED card35 S)
+	(NOT-BLOCKED card35 E)
+	(NOT-BLOCKED card35 N)
+
+	(NOT-BLOCKED card34 S)
+	(NOT-BLOCKED card34 N)
+
+	(NOT-BLOCKED card33 W)
+	(NOT-BLOCKED card33 N)
+
+	(NOT-BLOCKED card32 W)
+	(NOT-BLOCKED card32 S)
+	(NOT-BLOCKED card32 E)
+
+	(NOT-BLOCKED card31 W)
+	(NOT-BLOCKED card31 S)
+	(NOT-BLOCKED card31 E)
+
+	(NOT-BLOCKED card30 E)
+	(NOT-BLOCKED card30 N)
+
+	(NOT-BLOCKED card29 W)
+	(NOT-BLOCKED card29 S)
+
+	(NOT-BLOCKED card28 E)
+	(NOT-BLOCKED card28 N)
+
+	(NOT-BLOCKED card27 S)
+	(NOT-BLOCKED card27 N)
+
+	(NOT-BLOCKED card26 W)
+	(NOT-BLOCKED card26 E)
+	(NOT-BLOCKED card26 N)
+
+	(NOT-BLOCKED card25 W)
+	(NOT-BLOCKED card25 S)
+	(NOT-BLOCKED card25 E)
+
+	(NOT-BLOCKED card24 S)
+	(NOT-BLOCKED card24 N)
+
+	(NOT-BLOCKED card23 S)
+	(NOT-BLOCKED card23 E)
+
+	(NOT-BLOCKED card22 W)
+	(NOT-BLOCKED card22 S)
+	(NOT-BLOCKED card22 E)
+
+	(NOT-BLOCKED card21 S)
+	(NOT-BLOCKED card21 E)
+
+	(NOT-BLOCKED card20 S)
+	(NOT-BLOCKED card20 E)
+
+	(NOT-BLOCKED card19 W)
+	(NOT-BLOCKED card19 S)
+	(NOT-BLOCKED card19 N)
+
+	(NOT-BLOCKED card18 S)
+	(NOT-BLOCKED card18 E)
+
+	(NOT-BLOCKED card17 W)
+	(NOT-BLOCKED card17 S)
+	(NOT-BLOCKED card17 N)
+
+	(NOT-BLOCKED card16 W)
+	(NOT-BLOCKED card16 S)
+
+	(NOT-BLOCKED card15 W)
+	(NOT-BLOCKED card15 S)
+
+	(NOT-BLOCKED card14 E)
+	(NOT-BLOCKED card14 N)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 S)
+	(NOT-BLOCKED card13 E)
+
+	(NOT-BLOCKED card12 S)
+	(NOT-BLOCKED card12 E)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 W)
+	(NOT-BLOCKED card11 E)
+
+	(NOT-BLOCKED card10 W)
+	(NOT-BLOCKED card10 S)
+
+	(NOT-BLOCKED card9 S)
+	(NOT-BLOCKED card9 N)
+
+	(NOT-BLOCKED card8 W)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 W)
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 E)
+
+	(NOT-BLOCKED card6 W)
+	(NOT-BLOCKED card6 S)
+	(NOT-BLOCKED card6 N)
+
+	(NOT-BLOCKED card5 W)
+	(NOT-BLOCKED card5 E)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 S)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 N)
+
+	(NOT-BLOCKED card2 E)
+	(NOT-BLOCKED card2 N)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 S)
+	(NOT-BLOCKED card1 E)
+
+	(NOT-BLOCKED card0 W)
+	(NOT-BLOCKED card0 S)
+
+	(MAX-POS pos5)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+
+	(card-at card0 pos0 pos0)
+	(card-at card31 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card10 pos4 pos0)
+	(card-at card5 pos5 pos0)
+	(card-at card6 pos0 pos1)
+	(card-at card1 pos1 pos1)
+	(card-at card8 pos2 pos1)
+	(card-at card9 pos3 pos1)
+	(card-at card16 pos4 pos1)
+	(card-at card11 pos5 pos1)
+	(card-at card17 pos0 pos2)
+	(card-at card12 pos1 pos2)
+	(card-at card7 pos2 pos2)
+	(card-at card14 pos3 pos2)
+	(card-at card15 pos4 pos2)
+	(card-at card22 pos5 pos2)
+	(card-at card18 pos0 pos3)
+	(card-at card13 pos1 pos3)
+	(card-at card20 pos2 pos3)
+	(card-at card21 pos3 pos3)
+	(card-at card28 pos4 pos3)
+	(card-at card23 pos5 pos3)
+	(card-at card24 pos0 pos4)
+	(card-at card19 pos1 pos4)
+	(card-at card26 pos2 pos4)
+	(card-at card27 pos3 pos4)
+	(card-at card34 pos4 pos4)
+	(card-at card29 pos5 pos4)
+	(card-at card30 pos0 pos5)
+	(card-at card25 pos1 pos5)
+	(card-at card32 pos2 pos5)
+	(card-at card33 pos3 pos5)
+	(card-at card4 pos4 pos5)
+	(card-at card35 pos5 pos5)
+
+	(BLOCKED card0 N)
+	(BLOCKED card0 E)
+
+	(BLOCKED card31 N)
+
+	(BLOCKED card2 S)
+	(BLOCKED card2 W)
+
+	(BLOCKED card3 E)
+	(BLOCKED card3 S)
+
+	(BLOCKED card10 N)
+	(BLOCKED card10 E)
+
+	(BLOCKED card5 N)
+	(BLOCKED card5 S)
+
+	(BLOCKED card6 E)
+
+	(BLOCKED card1 N)
+
+	(BLOCKED card8 E)
+	(BLOCKED card8 S)
+
+	(BLOCKED card9 E)
+	(BLOCKED card9 W)
+
+	(BLOCKED card16 N)
+	(BLOCKED card16 E)
+
+	(BLOCKED card11 N)
+	(BLOCKED card11 S)
+
+	(BLOCKED card17 E)
+
+	(BLOCKED card12 W)
+
+	(BLOCKED card7 N)
+
+	(BLOCKED card14 S)
+	(BLOCKED card14 W)
+
+	(BLOCKED card15 N)
+	(BLOCKED card15 E)
+
+	(BLOCKED card22 N)
+
+	(BLOCKED card18 N)
+	(BLOCKED card18 W)
+
+	(BLOCKED card13 N)
+
+	(BLOCKED card20 N)
+	(BLOCKED card20 W)
+
+	(BLOCKED card21 N)
+	(BLOCKED card21 W)
+
+	(BLOCKED card28 S)
+	(BLOCKED card28 W)
+
+	(BLOCKED card23 N)
+	(BLOCKED card23 W)
+
+	(BLOCKED card24 E)
+	(BLOCKED card24 W)
+
+	(BLOCKED card19 E)
+
+	(BLOCKED card26 S)
+
+	(BLOCKED card27 E)
+	(BLOCKED card27 W)
+
+	(BLOCKED card34 E)
+	(BLOCKED card34 W)
+
+	(BLOCKED card29 N)
+	(BLOCKED card29 E)
+
+	(BLOCKED card30 S)
+	(BLOCKED card30 W)
+
+	(BLOCKED card25 N)
+
+	(BLOCKED card32 N)
+
+	(BLOCKED card33 E)
+	(BLOCKED card33 S)
+
+	(BLOCKED card4 N)
+	(BLOCKED card4 E)
+
+	(BLOCKED card35 W)
+
+
+	(robot-at card0)
+
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/SAT/p08.pddl
+++ b/labyrinth/SAT/p08.pddl
@@ -1,0 +1,320 @@
+;; Generated with seed: 1283, size: 6, num-rotations: 4
+(define (problem labyrinth-size-6-rotations-4-seed-1283)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35  - card
+)
+(:init
+	(NOT-BLOCKED card35 S)
+	(NOT-BLOCKED card35 N)
+
+	(NOT-BLOCKED card34 W)
+	(NOT-BLOCKED card34 N)
+
+	(NOT-BLOCKED card33 W)
+	(NOT-BLOCKED card33 E)
+	(NOT-BLOCKED card33 N)
+
+	(NOT-BLOCKED card32 W)
+	(NOT-BLOCKED card32 S)
+	(NOT-BLOCKED card32 E)
+
+	(NOT-BLOCKED card31 W)
+	(NOT-BLOCKED card31 E)
+
+	(NOT-BLOCKED card30 W)
+	(NOT-BLOCKED card30 E)
+	(NOT-BLOCKED card30 N)
+
+	(NOT-BLOCKED card29 S)
+	(NOT-BLOCKED card29 N)
+
+	(NOT-BLOCKED card28 S)
+	(NOT-BLOCKED card28 N)
+
+	(NOT-BLOCKED card27 W)
+	(NOT-BLOCKED card27 S)
+	(NOT-BLOCKED card27 E)
+
+	(NOT-BLOCKED card26 S)
+	(NOT-BLOCKED card26 N)
+
+	(NOT-BLOCKED card25 W)
+	(NOT-BLOCKED card25 N)
+
+	(NOT-BLOCKED card24 S)
+	(NOT-BLOCKED card24 E)
+	(NOT-BLOCKED card24 N)
+
+	(NOT-BLOCKED card23 W)
+	(NOT-BLOCKED card23 S)
+
+	(NOT-BLOCKED card22 S)
+	(NOT-BLOCKED card22 E)
+
+	(NOT-BLOCKED card21 W)
+	(NOT-BLOCKED card21 N)
+
+	(NOT-BLOCKED card20 W)
+	(NOT-BLOCKED card20 E)
+	(NOT-BLOCKED card20 N)
+
+	(NOT-BLOCKED card19 S)
+	(NOT-BLOCKED card19 E)
+
+	(NOT-BLOCKED card18 W)
+	(NOT-BLOCKED card18 S)
+	(NOT-BLOCKED card18 E)
+
+	(NOT-BLOCKED card17 W)
+	(NOT-BLOCKED card17 E)
+	(NOT-BLOCKED card17 N)
+
+	(NOT-BLOCKED card16 W)
+	(NOT-BLOCKED card16 S)
+
+	(NOT-BLOCKED card15 W)
+	(NOT-BLOCKED card15 E)
+	(NOT-BLOCKED card15 N)
+
+	(NOT-BLOCKED card14 W)
+	(NOT-BLOCKED card14 S)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 E)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 W)
+	(NOT-BLOCKED card12 E)
+
+	(NOT-BLOCKED card11 E)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 W)
+	(NOT-BLOCKED card10 E)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 S)
+	(NOT-BLOCKED card9 E)
+
+	(NOT-BLOCKED card8 S)
+	(NOT-BLOCKED card8 E)
+
+	(NOT-BLOCKED card7 W)
+	(NOT-BLOCKED card7 S)
+
+	(NOT-BLOCKED card6 W)
+	(NOT-BLOCKED card6 E)
+	(NOT-BLOCKED card6 N)
+
+	(NOT-BLOCKED card5 E)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 S)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 N)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 S)
+
+	(NOT-BLOCKED card1 E)
+	(NOT-BLOCKED card1 N)
+
+	(NOT-BLOCKED card0 W)
+	(NOT-BLOCKED card0 S)
+	(NOT-BLOCKED card0 E)
+	(NOT-BLOCKED card0 N)
+
+	(MAX-POS pos5)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card34 pos4 pos0)
+	(card-at card5 pos5 pos0)
+	(card-at card11 pos0 pos1)
+	(card-at card6 pos1 pos1)
+	(card-at card7 pos2 pos1)
+	(card-at card8 pos3 pos1)
+	(card-at card4 pos4 pos1)
+	(card-at card10 pos5 pos1)
+	(card-at card17 pos0 pos2)
+	(card-at card12 pos1 pos2)
+	(card-at card13 pos2 pos2)
+	(card-at card14 pos3 pos2)
+	(card-at card9 pos4 pos2)
+	(card-at card16 pos5 pos2)
+	(card-at card19 pos0 pos3)
+	(card-at card20 pos1 pos3)
+	(card-at card21 pos2 pos3)
+	(card-at card22 pos3 pos3)
+	(card-at card15 pos4 pos3)
+	(card-at card18 pos5 pos3)
+	(card-at card24 pos0 pos4)
+	(card-at card25 pos1 pos4)
+	(card-at card26 pos2 pos4)
+	(card-at card27 pos3 pos4)
+	(card-at card23 pos4 pos4)
+	(card-at card29 pos5 pos4)
+	(card-at card30 pos0 pos5)
+	(card-at card31 pos1 pos5)
+	(card-at card32 pos2 pos5)
+	(card-at card33 pos3 pos5)
+	(card-at card28 pos4 pos5)
+	(card-at card35 pos5 pos5)
+
+
+	(BLOCKED card1 S)
+	(BLOCKED card1 W)
+
+	(BLOCKED card2 N)
+	(BLOCKED card2 E)
+
+	(BLOCKED card3 E)
+	(BLOCKED card3 S)
+
+	(BLOCKED card34 E)
+	(BLOCKED card34 S)
+
+	(BLOCKED card5 S)
+	(BLOCKED card5 W)
+
+	(BLOCKED card11 S)
+	(BLOCKED card11 W)
+
+	(BLOCKED card6 S)
+
+	(BLOCKED card7 N)
+	(BLOCKED card7 E)
+
+	(BLOCKED card8 N)
+	(BLOCKED card8 W)
+
+	(BLOCKED card4 N)
+	(BLOCKED card4 E)
+
+	(BLOCKED card10 S)
+
+	(BLOCKED card17 S)
+
+	(BLOCKED card12 N)
+	(BLOCKED card12 S)
+
+	(BLOCKED card13 S)
+
+	(BLOCKED card14 N)
+	(BLOCKED card14 E)
+
+	(BLOCKED card9 N)
+	(BLOCKED card9 W)
+
+	(BLOCKED card16 N)
+	(BLOCKED card16 E)
+
+	(BLOCKED card19 N)
+	(BLOCKED card19 W)
+
+	(BLOCKED card20 S)
+
+	(BLOCKED card21 E)
+	(BLOCKED card21 S)
+
+	(BLOCKED card22 N)
+	(BLOCKED card22 W)
+
+	(BLOCKED card15 S)
+
+	(BLOCKED card18 N)
+
+	(BLOCKED card24 W)
+
+	(BLOCKED card25 E)
+	(BLOCKED card25 S)
+
+	(BLOCKED card26 E)
+	(BLOCKED card26 W)
+
+	(BLOCKED card27 N)
+
+	(BLOCKED card23 N)
+	(BLOCKED card23 E)
+
+	(BLOCKED card29 E)
+	(BLOCKED card29 W)
+
+	(BLOCKED card30 S)
+
+	(BLOCKED card31 N)
+	(BLOCKED card31 S)
+
+	(BLOCKED card32 N)
+
+	(BLOCKED card33 S)
+
+	(BLOCKED card28 E)
+	(BLOCKED card28 W)
+
+	(BLOCKED card35 E)
+	(BLOCKED card35 W)
+
+
+	(robot-at card0)
+
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/SAT/p09.pddl
+++ b/labyrinth/SAT/p09.pddl
@@ -1,0 +1,320 @@
+;; Generated with seed: 1289, size: 6, num-rotations: 6
+(define (problem labyrinth-size-6-rotations-6-seed-1289)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35  - card
+)
+(:init
+	(NOT-BLOCKED card35 W)
+	(NOT-BLOCKED card35 S)
+
+	(NOT-BLOCKED card34 W)
+	(NOT-BLOCKED card34 S)
+	(NOT-BLOCKED card34 E)
+
+	(NOT-BLOCKED card33 W)
+	(NOT-BLOCKED card33 E)
+
+	(NOT-BLOCKED card32 W)
+	(NOT-BLOCKED card32 E)
+
+	(NOT-BLOCKED card31 W)
+	(NOT-BLOCKED card31 E)
+	(NOT-BLOCKED card31 N)
+
+	(NOT-BLOCKED card30 S)
+	(NOT-BLOCKED card30 N)
+
+	(NOT-BLOCKED card29 E)
+	(NOT-BLOCKED card29 N)
+
+	(NOT-BLOCKED card28 W)
+	(NOT-BLOCKED card28 E)
+
+	(NOT-BLOCKED card27 W)
+	(NOT-BLOCKED card27 S)
+	(NOT-BLOCKED card27 E)
+
+	(NOT-BLOCKED card26 S)
+	(NOT-BLOCKED card26 E)
+	(NOT-BLOCKED card26 N)
+
+	(NOT-BLOCKED card25 S)
+	(NOT-BLOCKED card25 N)
+
+	(NOT-BLOCKED card24 W)
+	(NOT-BLOCKED card24 S)
+	(NOT-BLOCKED card24 E)
+
+	(NOT-BLOCKED card23 W)
+	(NOT-BLOCKED card23 E)
+
+	(NOT-BLOCKED card22 S)
+	(NOT-BLOCKED card22 E)
+
+	(NOT-BLOCKED card21 W)
+	(NOT-BLOCKED card21 S)
+
+	(NOT-BLOCKED card20 W)
+	(NOT-BLOCKED card20 E)
+
+	(NOT-BLOCKED card19 W)
+	(NOT-BLOCKED card19 S)
+	(NOT-BLOCKED card19 E)
+	(NOT-BLOCKED card19 N)
+
+	(NOT-BLOCKED card18 E)
+	(NOT-BLOCKED card18 N)
+
+	(NOT-BLOCKED card17 W)
+	(NOT-BLOCKED card17 N)
+
+	(NOT-BLOCKED card16 S)
+	(NOT-BLOCKED card16 E)
+	(NOT-BLOCKED card16 N)
+
+	(NOT-BLOCKED card15 S)
+	(NOT-BLOCKED card15 N)
+
+	(NOT-BLOCKED card14 S)
+	(NOT-BLOCKED card14 N)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 S)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 W)
+	(NOT-BLOCKED card12 E)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 S)
+	(NOT-BLOCKED card11 E)
+
+	(NOT-BLOCKED card10 S)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 S)
+	(NOT-BLOCKED card9 E)
+
+	(NOT-BLOCKED card8 S)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 S)
+	(NOT-BLOCKED card6 E)
+	(NOT-BLOCKED card6 N)
+
+	(NOT-BLOCKED card5 W)
+	(NOT-BLOCKED card5 S)
+	(NOT-BLOCKED card5 E)
+
+	(NOT-BLOCKED card4 S)
+	(NOT-BLOCKED card4 E)
+	(NOT-BLOCKED card4 N)
+
+	(NOT-BLOCKED card3 S)
+	(NOT-BLOCKED card3 E)
+	(NOT-BLOCKED card3 N)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 S)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 S)
+	(NOT-BLOCKED card1 E)
+
+	(NOT-BLOCKED card0 S)
+	(NOT-BLOCKED card0 N)
+
+	(MAX-POS pos5)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+
+	(card-at card0 pos0 pos0)
+	(card-at card14 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card34 pos4 pos0)
+	(card-at card5 pos5 pos0)
+	(card-at card6 pos0 pos1)
+	(card-at card13 pos1 pos1)
+	(card-at card8 pos2 pos1)
+	(card-at card9 pos3 pos1)
+	(card-at card4 pos4 pos1)
+	(card-at card11 pos5 pos1)
+	(card-at card7 pos0 pos2)
+	(card-at card19 pos1 pos2)
+	(card-at card15 pos2 pos2)
+	(card-at card16 pos3 pos2)
+	(card-at card10 pos4 pos2)
+	(card-at card12 pos5 pos2)
+	(card-at card18 pos0 pos3)
+	(card-at card24 pos1 pos3)
+	(card-at card20 pos2 pos3)
+	(card-at card21 pos3 pos3)
+	(card-at card17 pos4 pos3)
+	(card-at card23 pos5 pos3)
+	(card-at card29 pos0 pos4)
+	(card-at card31 pos1 pos4)
+	(card-at card25 pos2 pos4)
+	(card-at card26 pos3 pos4)
+	(card-at card22 pos4 pos4)
+	(card-at card28 pos5 pos4)
+	(card-at card30 pos0 pos5)
+	(card-at card1 pos1 pos5)
+	(card-at card32 pos2 pos5)
+	(card-at card33 pos3 pos5)
+	(card-at card27 pos4 pos5)
+	(card-at card35 pos5 pos5)
+
+	(BLOCKED card0 E)
+	(BLOCKED card0 W)
+
+	(BLOCKED card14 E)
+	(BLOCKED card14 W)
+
+	(BLOCKED card2 N)
+	(BLOCKED card2 E)
+
+	(BLOCKED card3 W)
+
+	(BLOCKED card34 N)
+
+	(BLOCKED card5 N)
+
+	(BLOCKED card6 W)
+
+	(BLOCKED card13 E)
+
+	(BLOCKED card8 E)
+	(BLOCKED card8 W)
+
+	(BLOCKED card9 N)
+	(BLOCKED card9 W)
+
+	(BLOCKED card4 W)
+
+	(BLOCKED card11 N)
+	(BLOCKED card11 W)
+
+	(BLOCKED card7 E)
+	(BLOCKED card7 W)
+
+
+	(BLOCKED card15 E)
+	(BLOCKED card15 W)
+
+	(BLOCKED card16 W)
+
+	(BLOCKED card10 E)
+	(BLOCKED card10 W)
+
+	(BLOCKED card12 S)
+
+	(BLOCKED card18 S)
+	(BLOCKED card18 W)
+
+	(BLOCKED card24 N)
+
+	(BLOCKED card20 N)
+	(BLOCKED card20 S)
+
+	(BLOCKED card21 N)
+	(BLOCKED card21 E)
+
+	(BLOCKED card17 E)
+	(BLOCKED card17 S)
+
+	(BLOCKED card23 N)
+	(BLOCKED card23 S)
+
+	(BLOCKED card29 S)
+	(BLOCKED card29 W)
+
+	(BLOCKED card31 S)
+
+	(BLOCKED card25 E)
+	(BLOCKED card25 W)
+
+	(BLOCKED card26 W)
+
+	(BLOCKED card22 N)
+	(BLOCKED card22 W)
+
+	(BLOCKED card28 N)
+	(BLOCKED card28 S)
+
+	(BLOCKED card30 E)
+	(BLOCKED card30 W)
+
+	(BLOCKED card1 N)
+
+	(BLOCKED card32 N)
+	(BLOCKED card32 S)
+
+	(BLOCKED card33 N)
+	(BLOCKED card33 S)
+
+	(BLOCKED card27 N)
+
+	(BLOCKED card35 N)
+	(BLOCKED card35 E)
+
+
+	(robot-at card0)
+
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/SAT/p10.pddl
+++ b/labyrinth/SAT/p10.pddl
@@ -1,0 +1,425 @@
+;; Generated with seed: 1291, size: 7, num-rotations: 1
+(define (problem labyrinth-size-7-rotations-1-seed-1291)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5 pos6  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35 card36 card37 card38 card39 card40 card41 card42 card43 card44 card45 card46 card47 card48  - card
+)
+(:init
+	(NOT-BLOCKED card48 W)
+	(NOT-BLOCKED card48 S)
+	(NOT-BLOCKED card48 N)
+
+	(NOT-BLOCKED card47 W)
+	(NOT-BLOCKED card47 S)
+	(NOT-BLOCKED card47 N)
+
+	(NOT-BLOCKED card46 S)
+	(NOT-BLOCKED card46 N)
+
+	(NOT-BLOCKED card45 W)
+	(NOT-BLOCKED card45 S)
+	(NOT-BLOCKED card45 N)
+
+	(NOT-BLOCKED card44 W)
+	(NOT-BLOCKED card44 E)
+
+	(NOT-BLOCKED card43 E)
+	(NOT-BLOCKED card43 N)
+
+	(NOT-BLOCKED card42 S)
+	(NOT-BLOCKED card42 E)
+	(NOT-BLOCKED card42 N)
+
+	(NOT-BLOCKED card41 W)
+	(NOT-BLOCKED card41 S)
+	(NOT-BLOCKED card41 E)
+	(NOT-BLOCKED card41 N)
+
+	(NOT-BLOCKED card40 W)
+	(NOT-BLOCKED card40 S)
+	(NOT-BLOCKED card40 E)
+
+	(NOT-BLOCKED card39 W)
+	(NOT-BLOCKED card39 E)
+
+	(NOT-BLOCKED card38 S)
+	(NOT-BLOCKED card38 E)
+	(NOT-BLOCKED card38 N)
+
+	(NOT-BLOCKED card37 W)
+	(NOT-BLOCKED card37 S)
+	(NOT-BLOCKED card37 E)
+	(NOT-BLOCKED card37 N)
+
+	(NOT-BLOCKED card36 S)
+	(NOT-BLOCKED card36 N)
+
+	(NOT-BLOCKED card35 S)
+	(NOT-BLOCKED card35 E)
+
+	(NOT-BLOCKED card34 S)
+	(NOT-BLOCKED card34 E)
+
+	(NOT-BLOCKED card33 S)
+	(NOT-BLOCKED card33 N)
+
+	(NOT-BLOCKED card32 W)
+	(NOT-BLOCKED card32 N)
+
+	(NOT-BLOCKED card31 W)
+	(NOT-BLOCKED card31 S)
+
+	(NOT-BLOCKED card30 W)
+	(NOT-BLOCKED card30 N)
+
+	(NOT-BLOCKED card29 W)
+	(NOT-BLOCKED card29 S)
+	(NOT-BLOCKED card29 N)
+
+	(NOT-BLOCKED card28 W)
+	(NOT-BLOCKED card28 E)
+
+	(NOT-BLOCKED card27 W)
+	(NOT-BLOCKED card27 S)
+
+	(NOT-BLOCKED card26 S)
+	(NOT-BLOCKED card26 N)
+
+	(NOT-BLOCKED card25 W)
+	(NOT-BLOCKED card25 S)
+	(NOT-BLOCKED card25 N)
+
+	(NOT-BLOCKED card24 W)
+	(NOT-BLOCKED card24 S)
+	(NOT-BLOCKED card24 N)
+
+	(NOT-BLOCKED card23 W)
+	(NOT-BLOCKED card23 S)
+
+	(NOT-BLOCKED card22 W)
+	(NOT-BLOCKED card22 S)
+
+	(NOT-BLOCKED card21 W)
+	(NOT-BLOCKED card21 E)
+	(NOT-BLOCKED card21 N)
+
+	(NOT-BLOCKED card20 W)
+	(NOT-BLOCKED card20 S)
+	(NOT-BLOCKED card20 N)
+
+	(NOT-BLOCKED card19 W)
+	(NOT-BLOCKED card19 S)
+	(NOT-BLOCKED card19 E)
+
+	(NOT-BLOCKED card18 W)
+	(NOT-BLOCKED card18 S)
+
+	(NOT-BLOCKED card17 S)
+	(NOT-BLOCKED card17 E)
+	(NOT-BLOCKED card17 N)
+
+	(NOT-BLOCKED card16 W)
+	(NOT-BLOCKED card16 E)
+
+	(NOT-BLOCKED card15 W)
+	(NOT-BLOCKED card15 N)
+
+	(NOT-BLOCKED card14 W)
+	(NOT-BLOCKED card14 S)
+	(NOT-BLOCKED card14 N)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 S)
+
+	(NOT-BLOCKED card12 W)
+	(NOT-BLOCKED card12 E)
+
+	(NOT-BLOCKED card11 W)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 S)
+	(NOT-BLOCKED card10 E)
+
+	(NOT-BLOCKED card9 W)
+	(NOT-BLOCKED card9 E)
+
+	(NOT-BLOCKED card8 E)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 W)
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 S)
+	(NOT-BLOCKED card6 N)
+
+	(NOT-BLOCKED card5 W)
+	(NOT-BLOCKED card5 S)
+
+	(NOT-BLOCKED card4 E)
+	(NOT-BLOCKED card4 N)
+
+	(NOT-BLOCKED card3 S)
+	(NOT-BLOCKED card3 E)
+	(NOT-BLOCKED card3 N)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 E)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 N)
+
+	(NOT-BLOCKED card0 S)
+	(NOT-BLOCKED card0 N)
+
+	(MAX-POS pos6)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+	(NEXT pos6 pos5)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card5 pos5 pos0)
+	(card-at card6 pos6 pos0)
+	(card-at card7 pos0 pos1)
+	(card-at card8 pos1 pos1)
+	(card-at card9 pos2 pos1)
+	(card-at card10 pos3 pos1)
+	(card-at card11 pos4 pos1)
+	(card-at card12 pos5 pos1)
+	(card-at card13 pos6 pos1)
+	(card-at card14 pos0 pos2)
+	(card-at card15 pos1 pos2)
+	(card-at card16 pos2 pos2)
+	(card-at card17 pos3 pos2)
+	(card-at card18 pos4 pos2)
+	(card-at card19 pos5 pos2)
+	(card-at card20 pos6 pos2)
+	(card-at card27 pos0 pos3)
+	(card-at card21 pos1 pos3)
+	(card-at card22 pos2 pos3)
+	(card-at card23 pos3 pos3)
+	(card-at card24 pos4 pos3)
+	(card-at card25 pos5 pos3)
+	(card-at card26 pos6 pos3)
+	(card-at card28 pos0 pos4)
+	(card-at card29 pos1 pos4)
+	(card-at card30 pos2 pos4)
+	(card-at card31 pos3 pos4)
+	(card-at card32 pos4 pos4)
+	(card-at card33 pos5 pos4)
+	(card-at card34 pos6 pos4)
+	(card-at card35 pos0 pos5)
+	(card-at card36 pos1 pos5)
+	(card-at card37 pos2 pos5)
+	(card-at card38 pos3 pos5)
+	(card-at card39 pos4 pos5)
+	(card-at card40 pos5 pos5)
+	(card-at card41 pos6 pos5)
+	(card-at card42 pos0 pos6)
+	(card-at card43 pos1 pos6)
+	(card-at card44 pos2 pos6)
+	(card-at card45 pos3 pos6)
+	(card-at card46 pos4 pos6)
+	(card-at card47 pos5 pos6)
+	(card-at card48 pos6 pos6)
+
+	(BLOCKED card0 E)
+	(BLOCKED card0 W)
+
+	(BLOCKED card1 E)
+	(BLOCKED card1 S)
+
+	(BLOCKED card2 N)
+	(BLOCKED card2 S)
+
+	(BLOCKED card3 W)
+
+	(BLOCKED card4 S)
+	(BLOCKED card4 W)
+
+	(BLOCKED card5 N)
+	(BLOCKED card5 E)
+
+	(BLOCKED card6 E)
+	(BLOCKED card6 W)
+
+	(BLOCKED card7 E)
+
+	(BLOCKED card8 S)
+	(BLOCKED card8 W)
+
+	(BLOCKED card9 N)
+	(BLOCKED card9 S)
+
+	(BLOCKED card10 N)
+	(BLOCKED card10 W)
+
+	(BLOCKED card11 E)
+	(BLOCKED card11 S)
+
+	(BLOCKED card12 N)
+	(BLOCKED card12 S)
+
+	(BLOCKED card13 N)
+	(BLOCKED card13 E)
+
+	(BLOCKED card14 E)
+
+	(BLOCKED card15 E)
+	(BLOCKED card15 S)
+
+	(BLOCKED card16 N)
+	(BLOCKED card16 S)
+
+	(BLOCKED card17 W)
+
+	(BLOCKED card18 N)
+	(BLOCKED card18 E)
+
+	(BLOCKED card19 N)
+
+	(BLOCKED card20 E)
+
+	(BLOCKED card27 N)
+	(BLOCKED card27 E)
+
+	(BLOCKED card21 S)
+
+	(BLOCKED card22 N)
+	(BLOCKED card22 E)
+
+	(BLOCKED card23 N)
+	(BLOCKED card23 E)
+
+	(BLOCKED card24 E)
+
+	(BLOCKED card25 E)
+
+	(BLOCKED card26 E)
+	(BLOCKED card26 W)
+
+	(BLOCKED card28 N)
+	(BLOCKED card28 S)
+
+	(BLOCKED card29 E)
+
+	(BLOCKED card30 E)
+	(BLOCKED card30 S)
+
+	(BLOCKED card31 N)
+	(BLOCKED card31 E)
+
+	(BLOCKED card32 E)
+	(BLOCKED card32 S)
+
+	(BLOCKED card33 E)
+	(BLOCKED card33 W)
+
+	(BLOCKED card34 N)
+	(BLOCKED card34 W)
+
+	(BLOCKED card35 N)
+	(BLOCKED card35 W)
+
+	(BLOCKED card36 E)
+	(BLOCKED card36 W)
+
+
+	(BLOCKED card38 W)
+
+	(BLOCKED card39 N)
+	(BLOCKED card39 S)
+
+	(BLOCKED card40 N)
+
+
+	(BLOCKED card42 W)
+
+	(BLOCKED card43 S)
+	(BLOCKED card43 W)
+
+	(BLOCKED card44 N)
+	(BLOCKED card44 S)
+
+	(BLOCKED card45 E)
+
+	(BLOCKED card46 E)
+	(BLOCKED card46 W)
+
+	(BLOCKED card47 E)
+
+	(BLOCKED card48 E)
+
+
+	(robot-at card0)
+
+	(not-robot-at card48)
+	(not-robot-at card47)
+	(not-robot-at card46)
+	(not-robot-at card45)
+	(not-robot-at card44)
+	(not-robot-at card43)
+	(not-robot-at card42)
+	(not-robot-at card41)
+	(not-robot-at card40)
+	(not-robot-at card39)
+	(not-robot-at card38)
+	(not-robot-at card37)
+	(not-robot-at card36)
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/SAT/p11.pddl
+++ b/labyrinth/SAT/p11.pddl
@@ -1,0 +1,425 @@
+;; Generated with seed: 1297, size: 7, num-rotations: 2
+(define (problem labyrinth-size-7-rotations-2-seed-1297)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5 pos6  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35 card36 card37 card38 card39 card40 card41 card42 card43 card44 card45 card46 card47 card48  - card
+)
+(:init
+	(NOT-BLOCKED card48 S)
+	(NOT-BLOCKED card48 N)
+
+	(NOT-BLOCKED card47 E)
+	(NOT-BLOCKED card47 N)
+
+	(NOT-BLOCKED card46 S)
+	(NOT-BLOCKED card46 E)
+
+	(NOT-BLOCKED card45 W)
+	(NOT-BLOCKED card45 S)
+
+	(NOT-BLOCKED card44 S)
+	(NOT-BLOCKED card44 E)
+
+	(NOT-BLOCKED card43 S)
+	(NOT-BLOCKED card43 E)
+
+	(NOT-BLOCKED card42 S)
+	(NOT-BLOCKED card42 E)
+	(NOT-BLOCKED card42 N)
+
+	(NOT-BLOCKED card41 W)
+	(NOT-BLOCKED card41 S)
+	(NOT-BLOCKED card41 N)
+
+	(NOT-BLOCKED card40 W)
+	(NOT-BLOCKED card40 E)
+	(NOT-BLOCKED card40 N)
+
+	(NOT-BLOCKED card39 E)
+	(NOT-BLOCKED card39 N)
+
+	(NOT-BLOCKED card38 W)
+	(NOT-BLOCKED card38 E)
+
+	(NOT-BLOCKED card37 S)
+	(NOT-BLOCKED card37 E)
+
+	(NOT-BLOCKED card36 W)
+	(NOT-BLOCKED card36 S)
+
+	(NOT-BLOCKED card35 S)
+	(NOT-BLOCKED card35 N)
+
+	(NOT-BLOCKED card34 W)
+	(NOT-BLOCKED card34 N)
+
+	(NOT-BLOCKED card33 S)
+	(NOT-BLOCKED card33 E)
+	(NOT-BLOCKED card33 N)
+
+	(NOT-BLOCKED card32 S)
+	(NOT-BLOCKED card32 E)
+	(NOT-BLOCKED card32 N)
+
+	(NOT-BLOCKED card31 S)
+	(NOT-BLOCKED card31 N)
+
+	(NOT-BLOCKED card30 W)
+	(NOT-BLOCKED card30 S)
+	(NOT-BLOCKED card30 E)
+	(NOT-BLOCKED card30 N)
+
+	(NOT-BLOCKED card29 S)
+	(NOT-BLOCKED card29 E)
+	(NOT-BLOCKED card29 N)
+
+	(NOT-BLOCKED card28 W)
+	(NOT-BLOCKED card28 E)
+	(NOT-BLOCKED card28 N)
+
+	(NOT-BLOCKED card27 W)
+	(NOT-BLOCKED card27 S)
+
+	(NOT-BLOCKED card26 S)
+	(NOT-BLOCKED card26 E)
+
+	(NOT-BLOCKED card25 W)
+	(NOT-BLOCKED card25 S)
+
+	(NOT-BLOCKED card24 W)
+	(NOT-BLOCKED card24 S)
+	(NOT-BLOCKED card24 E)
+
+	(NOT-BLOCKED card23 S)
+	(NOT-BLOCKED card23 E)
+
+	(NOT-BLOCKED card22 W)
+	(NOT-BLOCKED card22 S)
+	(NOT-BLOCKED card22 N)
+
+	(NOT-BLOCKED card21 E)
+	(NOT-BLOCKED card21 N)
+
+	(NOT-BLOCKED card20 S)
+	(NOT-BLOCKED card20 E)
+
+	(NOT-BLOCKED card19 S)
+	(NOT-BLOCKED card19 E)
+	(NOT-BLOCKED card19 N)
+
+	(NOT-BLOCKED card18 S)
+	(NOT-BLOCKED card18 N)
+
+	(NOT-BLOCKED card17 S)
+	(NOT-BLOCKED card17 E)
+
+	(NOT-BLOCKED card16 S)
+	(NOT-BLOCKED card16 E)
+
+	(NOT-BLOCKED card15 E)
+	(NOT-BLOCKED card15 N)
+
+	(NOT-BLOCKED card14 S)
+	(NOT-BLOCKED card14 N)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 E)
+
+	(NOT-BLOCKED card12 E)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 S)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 W)
+	(NOT-BLOCKED card10 S)
+
+	(NOT-BLOCKED card9 S)
+	(NOT-BLOCKED card9 E)
+	(NOT-BLOCKED card9 N)
+
+	(NOT-BLOCKED card8 W)
+	(NOT-BLOCKED card8 E)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 W)
+	(NOT-BLOCKED card6 S)
+
+	(NOT-BLOCKED card5 S)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 E)
+	(NOT-BLOCKED card4 N)
+
+	(NOT-BLOCKED card3 S)
+	(NOT-BLOCKED card3 E)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 E)
+
+	(NOT-BLOCKED card1 S)
+	(NOT-BLOCKED card1 E)
+	(NOT-BLOCKED card1 N)
+
+	(NOT-BLOCKED card0 S)
+	(NOT-BLOCKED card0 N)
+
+	(MAX-POS pos6)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+	(NEXT pos6 pos5)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card47 pos5 pos0)
+	(card-at card6 pos6 pos0)
+	(card-at card7 pos0 pos1)
+	(card-at card8 pos1 pos1)
+	(card-at card9 pos2 pos1)
+	(card-at card10 pos3 pos1)
+	(card-at card11 pos4 pos1)
+	(card-at card5 pos5 pos1)
+	(card-at card13 pos6 pos1)
+	(card-at card14 pos0 pos2)
+	(card-at card15 pos1 pos2)
+	(card-at card16 pos2 pos2)
+	(card-at card17 pos3 pos2)
+	(card-at card18 pos4 pos2)
+	(card-at card12 pos5 pos2)
+	(card-at card20 pos6 pos2)
+	(card-at card21 pos0 pos3)
+	(card-at card22 pos1 pos3)
+	(card-at card23 pos2 pos3)
+	(card-at card24 pos3 pos3)
+	(card-at card25 pos4 pos3)
+	(card-at card19 pos5 pos3)
+	(card-at card27 pos6 pos3)
+	(card-at card34 pos0 pos4)
+	(card-at card28 pos1 pos4)
+	(card-at card29 pos2 pos4)
+	(card-at card30 pos3 pos4)
+	(card-at card31 pos4 pos4)
+	(card-at card32 pos5 pos4)
+	(card-at card26 pos6 pos4)
+	(card-at card35 pos0 pos5)
+	(card-at card36 pos1 pos5)
+	(card-at card37 pos2 pos5)
+	(card-at card38 pos3 pos5)
+	(card-at card39 pos4 pos5)
+	(card-at card33 pos5 pos5)
+	(card-at card41 pos6 pos5)
+	(card-at card42 pos0 pos6)
+	(card-at card43 pos1 pos6)
+	(card-at card44 pos2 pos6)
+	(card-at card45 pos3 pos6)
+	(card-at card46 pos4 pos6)
+	(card-at card40 pos5 pos6)
+	(card-at card48 pos6 pos6)
+
+	(BLOCKED card0 E)
+	(BLOCKED card0 W)
+
+	(BLOCKED card1 W)
+
+	(BLOCKED card2 N)
+	(BLOCKED card2 S)
+
+	(BLOCKED card3 N)
+	(BLOCKED card3 W)
+
+	(BLOCKED card4 S)
+
+	(BLOCKED card47 S)
+	(BLOCKED card47 W)
+
+	(BLOCKED card6 N)
+	(BLOCKED card6 E)
+
+	(BLOCKED card7 E)
+	(BLOCKED card7 W)
+
+	(BLOCKED card8 S)
+
+	(BLOCKED card9 W)
+
+	(BLOCKED card10 N)
+	(BLOCKED card10 E)
+
+	(BLOCKED card11 E)
+	(BLOCKED card11 W)
+
+	(BLOCKED card5 E)
+	(BLOCKED card5 W)
+
+	(BLOCKED card13 N)
+	(BLOCKED card13 S)
+
+	(BLOCKED card14 E)
+	(BLOCKED card14 W)
+
+	(BLOCKED card15 S)
+	(BLOCKED card15 W)
+
+	(BLOCKED card16 N)
+	(BLOCKED card16 W)
+
+	(BLOCKED card17 N)
+	(BLOCKED card17 W)
+
+	(BLOCKED card18 E)
+	(BLOCKED card18 W)
+
+	(BLOCKED card12 S)
+	(BLOCKED card12 W)
+
+	(BLOCKED card20 N)
+	(BLOCKED card20 W)
+
+	(BLOCKED card21 S)
+	(BLOCKED card21 W)
+
+	(BLOCKED card22 E)
+
+	(BLOCKED card23 N)
+	(BLOCKED card23 W)
+
+	(BLOCKED card24 N)
+
+	(BLOCKED card25 N)
+	(BLOCKED card25 E)
+
+	(BLOCKED card19 W)
+
+	(BLOCKED card27 N)
+	(BLOCKED card27 E)
+
+	(BLOCKED card34 E)
+	(BLOCKED card34 S)
+
+	(BLOCKED card28 S)
+
+	(BLOCKED card29 W)
+
+
+	(BLOCKED card31 E)
+	(BLOCKED card31 W)
+
+	(BLOCKED card32 W)
+
+	(BLOCKED card26 N)
+	(BLOCKED card26 W)
+
+	(BLOCKED card35 E)
+	(BLOCKED card35 W)
+
+	(BLOCKED card36 N)
+	(BLOCKED card36 E)
+
+	(BLOCKED card37 N)
+	(BLOCKED card37 W)
+
+	(BLOCKED card38 N)
+	(BLOCKED card38 S)
+
+	(BLOCKED card39 S)
+	(BLOCKED card39 W)
+
+	(BLOCKED card33 W)
+
+	(BLOCKED card41 E)
+
+	(BLOCKED card42 W)
+
+	(BLOCKED card43 N)
+	(BLOCKED card43 W)
+
+	(BLOCKED card44 N)
+	(BLOCKED card44 W)
+
+	(BLOCKED card45 N)
+	(BLOCKED card45 E)
+
+	(BLOCKED card46 N)
+	(BLOCKED card46 W)
+
+	(BLOCKED card40 S)
+
+	(BLOCKED card48 E)
+	(BLOCKED card48 W)
+
+
+	(robot-at card0)
+
+	(not-robot-at card48)
+	(not-robot-at card47)
+	(not-robot-at card46)
+	(not-robot-at card45)
+	(not-robot-at card44)
+	(not-robot-at card43)
+	(not-robot-at card42)
+	(not-robot-at card41)
+	(not-robot-at card40)
+	(not-robot-at card39)
+	(not-robot-at card38)
+	(not-robot-at card37)
+	(not-robot-at card36)
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/SAT/p12.pddl
+++ b/labyrinth/SAT/p12.pddl
@@ -1,0 +1,425 @@
+;; Generated with seed: 1301, size: 7, num-rotations: 3
+(define (problem labyrinth-size-7-rotations-3-seed-1301)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5 pos6  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35 card36 card37 card38 card39 card40 card41 card42 card43 card44 card45 card46 card47 card48  - card
+)
+(:init
+	(NOT-BLOCKED card48 W)
+	(NOT-BLOCKED card48 S)
+	(NOT-BLOCKED card48 E)
+	(NOT-BLOCKED card48 N)
+
+	(NOT-BLOCKED card47 W)
+	(NOT-BLOCKED card47 E)
+	(NOT-BLOCKED card47 N)
+
+	(NOT-BLOCKED card46 W)
+	(NOT-BLOCKED card46 E)
+
+	(NOT-BLOCKED card45 W)
+	(NOT-BLOCKED card45 E)
+
+	(NOT-BLOCKED card44 W)
+	(NOT-BLOCKED card44 S)
+	(NOT-BLOCKED card44 E)
+	(NOT-BLOCKED card44 N)
+
+	(NOT-BLOCKED card43 W)
+	(NOT-BLOCKED card43 E)
+
+	(NOT-BLOCKED card42 E)
+	(NOT-BLOCKED card42 N)
+
+	(NOT-BLOCKED card41 W)
+	(NOT-BLOCKED card41 E)
+	(NOT-BLOCKED card41 N)
+
+	(NOT-BLOCKED card40 W)
+	(NOT-BLOCKED card40 E)
+	(NOT-BLOCKED card40 N)
+
+	(NOT-BLOCKED card39 W)
+	(NOT-BLOCKED card39 S)
+
+	(NOT-BLOCKED card38 S)
+	(NOT-BLOCKED card38 N)
+
+	(NOT-BLOCKED card37 S)
+	(NOT-BLOCKED card37 E)
+
+	(NOT-BLOCKED card36 S)
+	(NOT-BLOCKED card36 N)
+
+	(NOT-BLOCKED card35 W)
+	(NOT-BLOCKED card35 S)
+	(NOT-BLOCKED card35 N)
+
+	(NOT-BLOCKED card34 W)
+	(NOT-BLOCKED card34 S)
+	(NOT-BLOCKED card34 N)
+
+	(NOT-BLOCKED card33 S)
+	(NOT-BLOCKED card33 N)
+
+	(NOT-BLOCKED card32 W)
+	(NOT-BLOCKED card32 N)
+
+	(NOT-BLOCKED card31 E)
+	(NOT-BLOCKED card31 N)
+
+	(NOT-BLOCKED card30 W)
+	(NOT-BLOCKED card30 N)
+
+	(NOT-BLOCKED card29 W)
+	(NOT-BLOCKED card29 S)
+	(NOT-BLOCKED card29 E)
+	(NOT-BLOCKED card29 N)
+
+	(NOT-BLOCKED card28 W)
+	(NOT-BLOCKED card28 S)
+	(NOT-BLOCKED card28 E)
+	(NOT-BLOCKED card28 N)
+
+	(NOT-BLOCKED card27 S)
+	(NOT-BLOCKED card27 E)
+	(NOT-BLOCKED card27 N)
+
+	(NOT-BLOCKED card26 S)
+	(NOT-BLOCKED card26 E)
+
+	(NOT-BLOCKED card25 W)
+	(NOT-BLOCKED card25 S)
+
+	(NOT-BLOCKED card24 S)
+	(NOT-BLOCKED card24 N)
+
+	(NOT-BLOCKED card23 W)
+	(NOT-BLOCKED card23 N)
+
+	(NOT-BLOCKED card22 S)
+	(NOT-BLOCKED card22 N)
+
+	(NOT-BLOCKED card21 S)
+	(NOT-BLOCKED card21 N)
+
+	(NOT-BLOCKED card20 W)
+	(NOT-BLOCKED card20 E)
+
+	(NOT-BLOCKED card19 S)
+	(NOT-BLOCKED card19 N)
+
+	(NOT-BLOCKED card18 W)
+	(NOT-BLOCKED card18 E)
+	(NOT-BLOCKED card18 N)
+
+	(NOT-BLOCKED card17 S)
+	(NOT-BLOCKED card17 E)
+
+	(NOT-BLOCKED card16 S)
+	(NOT-BLOCKED card16 N)
+
+	(NOT-BLOCKED card15 W)
+	(NOT-BLOCKED card15 S)
+	(NOT-BLOCKED card15 E)
+
+	(NOT-BLOCKED card14 S)
+	(NOT-BLOCKED card14 E)
+	(NOT-BLOCKED card14 N)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 W)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 W)
+	(NOT-BLOCKED card11 S)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 E)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 S)
+	(NOT-BLOCKED card9 E)
+
+	(NOT-BLOCKED card8 W)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 E)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 S)
+	(NOT-BLOCKED card6 E)
+	(NOT-BLOCKED card6 N)
+
+	(NOT-BLOCKED card5 W)
+	(NOT-BLOCKED card5 S)
+	(NOT-BLOCKED card5 E)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 E)
+
+	(NOT-BLOCKED card3 S)
+	(NOT-BLOCKED card3 N)
+
+	(NOT-BLOCKED card2 E)
+	(NOT-BLOCKED card2 N)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 E)
+	(NOT-BLOCKED card1 N)
+
+	(NOT-BLOCKED card0 W)
+	(NOT-BLOCKED card0 S)
+
+	(MAX-POS pos6)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+	(NEXT pos6 pos5)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card10 pos3 pos0)
+	(card-at card46 pos4 pos0)
+	(card-at card5 pos5 pos0)
+	(card-at card6 pos6 pos0)
+	(card-at card7 pos0 pos1)
+	(card-at card8 pos1 pos1)
+	(card-at card9 pos2 pos1)
+	(card-at card18 pos3 pos1)
+	(card-at card4 pos4 pos1)
+	(card-at card12 pos5 pos1)
+	(card-at card13 pos6 pos1)
+	(card-at card15 pos0 pos2)
+	(card-at card16 pos1 pos2)
+	(card-at card17 pos2 pos2)
+	(card-at card24 pos3 pos2)
+	(card-at card11 pos4 pos2)
+	(card-at card20 pos5 pos2)
+	(card-at card14 pos6 pos2)
+	(card-at card21 pos0 pos3)
+	(card-at card22 pos1 pos3)
+	(card-at card23 pos2 pos3)
+	(card-at card31 pos3 pos3)
+	(card-at card19 pos4 pos3)
+	(card-at card26 pos5 pos3)
+	(card-at card27 pos6 pos3)
+	(card-at card28 pos0 pos4)
+	(card-at card29 pos1 pos4)
+	(card-at card30 pos2 pos4)
+	(card-at card38 pos3 pos4)
+	(card-at card25 pos4 pos4)
+	(card-at card33 pos5 pos4)
+	(card-at card34 pos6 pos4)
+	(card-at card35 pos0 pos5)
+	(card-at card36 pos1 pos5)
+	(card-at card37 pos2 pos5)
+	(card-at card45 pos3 pos5)
+	(card-at card32 pos4 pos5)
+	(card-at card40 pos5 pos5)
+	(card-at card41 pos6 pos5)
+	(card-at card42 pos0 pos6)
+	(card-at card43 pos1 pos6)
+	(card-at card44 pos2 pos6)
+	(card-at card3 pos3 pos6)
+	(card-at card39 pos4 pos6)
+	(card-at card47 pos5 pos6)
+	(card-at card48 pos6 pos6)
+
+	(BLOCKED card0 N)
+	(BLOCKED card0 E)
+
+	(BLOCKED card1 S)
+
+	(BLOCKED card2 S)
+	(BLOCKED card2 W)
+
+	(BLOCKED card10 S)
+	(BLOCKED card10 W)
+
+	(BLOCKED card46 N)
+	(BLOCKED card46 S)
+
+	(BLOCKED card5 N)
+
+	(BLOCKED card6 W)
+
+	(BLOCKED card7 W)
+
+	(BLOCKED card8 E)
+	(BLOCKED card8 S)
+
+	(BLOCKED card9 N)
+	(BLOCKED card9 W)
+
+	(BLOCKED card18 S)
+
+	(BLOCKED card4 N)
+	(BLOCKED card4 S)
+
+	(BLOCKED card12 E)
+	(BLOCKED card12 S)
+
+	(BLOCKED card13 E)
+	(BLOCKED card13 S)
+
+	(BLOCKED card15 N)
+
+	(BLOCKED card16 E)
+	(BLOCKED card16 W)
+
+	(BLOCKED card17 N)
+	(BLOCKED card17 W)
+
+	(BLOCKED card24 E)
+	(BLOCKED card24 W)
+
+	(BLOCKED card11 E)
+
+	(BLOCKED card20 N)
+	(BLOCKED card20 S)
+
+	(BLOCKED card14 W)
+
+	(BLOCKED card21 E)
+	(BLOCKED card21 W)
+
+	(BLOCKED card22 E)
+	(BLOCKED card22 W)
+
+	(BLOCKED card23 E)
+	(BLOCKED card23 S)
+
+	(BLOCKED card31 S)
+	(BLOCKED card31 W)
+
+	(BLOCKED card19 E)
+	(BLOCKED card19 W)
+
+	(BLOCKED card26 N)
+	(BLOCKED card26 W)
+
+	(BLOCKED card27 W)
+
+
+
+	(BLOCKED card30 E)
+	(BLOCKED card30 S)
+
+	(BLOCKED card38 E)
+	(BLOCKED card38 W)
+
+	(BLOCKED card25 N)
+	(BLOCKED card25 E)
+
+	(BLOCKED card33 E)
+	(BLOCKED card33 W)
+
+	(BLOCKED card34 E)
+
+	(BLOCKED card35 E)
+
+	(BLOCKED card36 E)
+	(BLOCKED card36 W)
+
+	(BLOCKED card37 N)
+	(BLOCKED card37 W)
+
+	(BLOCKED card45 N)
+	(BLOCKED card45 S)
+
+	(BLOCKED card32 E)
+	(BLOCKED card32 S)
+
+	(BLOCKED card40 S)
+
+	(BLOCKED card41 S)
+
+	(BLOCKED card42 S)
+	(BLOCKED card42 W)
+
+	(BLOCKED card43 N)
+	(BLOCKED card43 S)
+
+
+	(BLOCKED card3 E)
+	(BLOCKED card3 W)
+
+	(BLOCKED card39 N)
+	(BLOCKED card39 E)
+
+	(BLOCKED card47 S)
+
+
+
+	(robot-at card0)
+
+	(not-robot-at card48)
+	(not-robot-at card47)
+	(not-robot-at card46)
+	(not-robot-at card45)
+	(not-robot-at card44)
+	(not-robot-at card43)
+	(not-robot-at card42)
+	(not-robot-at card41)
+	(not-robot-at card40)
+	(not-robot-at card39)
+	(not-robot-at card38)
+	(not-robot-at card37)
+	(not-robot-at card36)
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/SAT/p13.pddl
+++ b/labyrinth/SAT/p13.pddl
@@ -1,0 +1,425 @@
+;; Generated with seed: 1303, size: 7, num-rotations: 4
+(define (problem labyrinth-size-7-rotations-4-seed-1303)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5 pos6  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35 card36 card37 card38 card39 card40 card41 card42 card43 card44 card45 card46 card47 card48  - card
+)
+(:init
+	(NOT-BLOCKED card48 W)
+	(NOT-BLOCKED card48 S)
+
+	(NOT-BLOCKED card47 W)
+	(NOT-BLOCKED card47 E)
+
+	(NOT-BLOCKED card46 W)
+	(NOT-BLOCKED card46 E)
+
+	(NOT-BLOCKED card45 S)
+	(NOT-BLOCKED card45 E)
+	(NOT-BLOCKED card45 N)
+
+	(NOT-BLOCKED card44 E)
+	(NOT-BLOCKED card44 N)
+
+	(NOT-BLOCKED card43 S)
+	(NOT-BLOCKED card43 E)
+
+	(NOT-BLOCKED card42 W)
+	(NOT-BLOCKED card42 E)
+
+	(NOT-BLOCKED card41 S)
+	(NOT-BLOCKED card41 N)
+
+	(NOT-BLOCKED card40 W)
+	(NOT-BLOCKED card40 N)
+
+	(NOT-BLOCKED card39 W)
+	(NOT-BLOCKED card39 E)
+	(NOT-BLOCKED card39 N)
+
+	(NOT-BLOCKED card38 S)
+	(NOT-BLOCKED card38 E)
+	(NOT-BLOCKED card38 N)
+
+	(NOT-BLOCKED card37 W)
+	(NOT-BLOCKED card37 S)
+	(NOT-BLOCKED card37 N)
+
+	(NOT-BLOCKED card36 W)
+	(NOT-BLOCKED card36 E)
+
+	(NOT-BLOCKED card35 S)
+	(NOT-BLOCKED card35 E)
+
+	(NOT-BLOCKED card34 W)
+	(NOT-BLOCKED card34 N)
+
+	(NOT-BLOCKED card33 S)
+	(NOT-BLOCKED card33 E)
+
+	(NOT-BLOCKED card32 S)
+	(NOT-BLOCKED card32 N)
+
+	(NOT-BLOCKED card31 W)
+	(NOT-BLOCKED card31 N)
+
+	(NOT-BLOCKED card30 E)
+	(NOT-BLOCKED card30 N)
+
+	(NOT-BLOCKED card29 S)
+	(NOT-BLOCKED card29 E)
+	(NOT-BLOCKED card29 N)
+
+	(NOT-BLOCKED card28 S)
+	(NOT-BLOCKED card28 N)
+
+	(NOT-BLOCKED card27 W)
+	(NOT-BLOCKED card27 S)
+	(NOT-BLOCKED card27 E)
+
+	(NOT-BLOCKED card26 E)
+	(NOT-BLOCKED card26 N)
+
+	(NOT-BLOCKED card25 W)
+	(NOT-BLOCKED card25 E)
+	(NOT-BLOCKED card25 N)
+
+	(NOT-BLOCKED card24 W)
+	(NOT-BLOCKED card24 E)
+
+	(NOT-BLOCKED card23 W)
+	(NOT-BLOCKED card23 S)
+
+	(NOT-BLOCKED card22 W)
+	(NOT-BLOCKED card22 S)
+
+	(NOT-BLOCKED card21 W)
+	(NOT-BLOCKED card21 S)
+	(NOT-BLOCKED card21 N)
+
+	(NOT-BLOCKED card20 W)
+	(NOT-BLOCKED card20 N)
+
+	(NOT-BLOCKED card19 W)
+	(NOT-BLOCKED card19 S)
+
+	(NOT-BLOCKED card18 W)
+	(NOT-BLOCKED card18 E)
+	(NOT-BLOCKED card18 N)
+
+	(NOT-BLOCKED card17 W)
+	(NOT-BLOCKED card17 E)
+	(NOT-BLOCKED card17 N)
+
+	(NOT-BLOCKED card16 W)
+	(NOT-BLOCKED card16 E)
+
+	(NOT-BLOCKED card15 S)
+	(NOT-BLOCKED card15 E)
+	(NOT-BLOCKED card15 N)
+
+	(NOT-BLOCKED card14 W)
+	(NOT-BLOCKED card14 S)
+	(NOT-BLOCKED card14 N)
+
+	(NOT-BLOCKED card13 S)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 S)
+	(NOT-BLOCKED card12 E)
+
+	(NOT-BLOCKED card11 S)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 W)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 E)
+	(NOT-BLOCKED card9 N)
+
+	(NOT-BLOCKED card8 W)
+	(NOT-BLOCKED card8 S)
+	(NOT-BLOCKED card8 E)
+
+	(NOT-BLOCKED card7 E)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 W)
+	(NOT-BLOCKED card6 S)
+	(NOT-BLOCKED card6 E)
+
+	(NOT-BLOCKED card5 W)
+	(NOT-BLOCKED card5 E)
+
+	(NOT-BLOCKED card4 S)
+	(NOT-BLOCKED card4 N)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 E)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 E)
+
+	(NOT-BLOCKED card1 S)
+	(NOT-BLOCKED card1 N)
+
+	(NOT-BLOCKED card0 W)
+	(NOT-BLOCKED card0 S)
+
+	(MAX-POS pos6)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+	(NEXT pos6 pos5)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card5 pos5 pos0)
+	(card-at card6 pos6 pos0)
+	(card-at card9 pos0 pos1)
+	(card-at card10 pos1 pos1)
+	(card-at card11 pos2 pos1)
+	(card-at card12 pos3 pos1)
+	(card-at card13 pos4 pos1)
+	(card-at card7 pos5 pos1)
+	(card-at card8 pos6 pos1)
+	(card-at card20 pos0 pos2)
+	(card-at card14 pos1 pos2)
+	(card-at card15 pos2 pos2)
+	(card-at card16 pos3 pos2)
+	(card-at card17 pos4 pos2)
+	(card-at card18 pos5 pos2)
+	(card-at card19 pos6 pos2)
+	(card-at card22 pos0 pos3)
+	(card-at card23 pos1 pos3)
+	(card-at card24 pos2 pos3)
+	(card-at card25 pos3 pos3)
+	(card-at card26 pos4 pos3)
+	(card-at card27 pos5 pos3)
+	(card-at card21 pos6 pos3)
+	(card-at card28 pos0 pos4)
+	(card-at card29 pos1 pos4)
+	(card-at card30 pos2 pos4)
+	(card-at card31 pos3 pos4)
+	(card-at card32 pos4 pos4)
+	(card-at card33 pos5 pos4)
+	(card-at card34 pos6 pos4)
+	(card-at card35 pos0 pos5)
+	(card-at card36 pos1 pos5)
+	(card-at card37 pos2 pos5)
+	(card-at card38 pos3 pos5)
+	(card-at card39 pos4 pos5)
+	(card-at card40 pos5 pos5)
+	(card-at card41 pos6 pos5)
+	(card-at card42 pos0 pos6)
+	(card-at card43 pos1 pos6)
+	(card-at card44 pos2 pos6)
+	(card-at card45 pos3 pos6)
+	(card-at card46 pos4 pos6)
+	(card-at card47 pos5 pos6)
+	(card-at card48 pos6 pos6)
+
+	(BLOCKED card0 N)
+	(BLOCKED card0 E)
+
+	(BLOCKED card1 E)
+	(BLOCKED card1 W)
+
+	(BLOCKED card2 N)
+	(BLOCKED card2 S)
+
+	(BLOCKED card3 N)
+	(BLOCKED card3 S)
+
+	(BLOCKED card4 E)
+	(BLOCKED card4 W)
+
+	(BLOCKED card5 N)
+	(BLOCKED card5 S)
+
+	(BLOCKED card6 N)
+
+	(BLOCKED card9 S)
+	(BLOCKED card9 W)
+
+	(BLOCKED card10 E)
+	(BLOCKED card10 S)
+
+	(BLOCKED card11 E)
+	(BLOCKED card11 W)
+
+	(BLOCKED card12 N)
+	(BLOCKED card12 W)
+
+	(BLOCKED card13 E)
+	(BLOCKED card13 W)
+
+	(BLOCKED card7 S)
+	(BLOCKED card7 W)
+
+	(BLOCKED card8 N)
+
+	(BLOCKED card20 E)
+	(BLOCKED card20 S)
+
+	(BLOCKED card14 E)
+
+	(BLOCKED card15 W)
+
+	(BLOCKED card16 N)
+	(BLOCKED card16 S)
+
+	(BLOCKED card17 S)
+
+	(BLOCKED card18 S)
+
+	(BLOCKED card19 N)
+	(BLOCKED card19 E)
+
+	(BLOCKED card22 N)
+	(BLOCKED card22 E)
+
+	(BLOCKED card23 N)
+	(BLOCKED card23 E)
+
+	(BLOCKED card24 N)
+	(BLOCKED card24 S)
+
+	(BLOCKED card25 S)
+
+	(BLOCKED card26 S)
+	(BLOCKED card26 W)
+
+	(BLOCKED card27 N)
+
+	(BLOCKED card21 E)
+
+	(BLOCKED card28 E)
+	(BLOCKED card28 W)
+
+	(BLOCKED card29 W)
+
+	(BLOCKED card30 S)
+	(BLOCKED card30 W)
+
+	(BLOCKED card31 E)
+	(BLOCKED card31 S)
+
+	(BLOCKED card32 E)
+	(BLOCKED card32 W)
+
+	(BLOCKED card33 N)
+	(BLOCKED card33 W)
+
+	(BLOCKED card34 E)
+	(BLOCKED card34 S)
+
+	(BLOCKED card35 N)
+	(BLOCKED card35 W)
+
+	(BLOCKED card36 N)
+	(BLOCKED card36 S)
+
+	(BLOCKED card37 E)
+
+	(BLOCKED card38 W)
+
+	(BLOCKED card39 S)
+
+	(BLOCKED card40 E)
+	(BLOCKED card40 S)
+
+	(BLOCKED card41 E)
+	(BLOCKED card41 W)
+
+	(BLOCKED card42 N)
+	(BLOCKED card42 S)
+
+	(BLOCKED card43 N)
+	(BLOCKED card43 W)
+
+	(BLOCKED card44 S)
+	(BLOCKED card44 W)
+
+	(BLOCKED card45 W)
+
+	(BLOCKED card46 N)
+	(BLOCKED card46 S)
+
+	(BLOCKED card47 N)
+	(BLOCKED card47 S)
+
+	(BLOCKED card48 N)
+	(BLOCKED card48 E)
+
+
+	(robot-at card0)
+
+	(not-robot-at card48)
+	(not-robot-at card47)
+	(not-robot-at card46)
+	(not-robot-at card45)
+	(not-robot-at card44)
+	(not-robot-at card43)
+	(not-robot-at card42)
+	(not-robot-at card41)
+	(not-robot-at card40)
+	(not-robot-at card39)
+	(not-robot-at card38)
+	(not-robot-at card37)
+	(not-robot-at card36)
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/SAT/p14.pddl
+++ b/labyrinth/SAT/p14.pddl
@@ -1,0 +1,425 @@
+;; Generated with seed: 1307, size: 7, num-rotations: 6
+(define (problem labyrinth-size-7-rotations-6-seed-1307)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5 pos6  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35 card36 card37 card38 card39 card40 card41 card42 card43 card44 card45 card46 card47 card48  - card
+)
+(:init
+	(NOT-BLOCKED card48 S)
+	(NOT-BLOCKED card48 E)
+	(NOT-BLOCKED card48 N)
+
+	(NOT-BLOCKED card47 S)
+	(NOT-BLOCKED card47 N)
+
+	(NOT-BLOCKED card46 W)
+	(NOT-BLOCKED card46 S)
+
+	(NOT-BLOCKED card45 W)
+	(NOT-BLOCKED card45 S)
+	(NOT-BLOCKED card45 E)
+
+	(NOT-BLOCKED card44 S)
+	(NOT-BLOCKED card44 E)
+
+	(NOT-BLOCKED card43 S)
+	(NOT-BLOCKED card43 N)
+
+	(NOT-BLOCKED card42 S)
+	(NOT-BLOCKED card42 N)
+
+	(NOT-BLOCKED card41 S)
+	(NOT-BLOCKED card41 N)
+
+	(NOT-BLOCKED card40 S)
+	(NOT-BLOCKED card40 E)
+
+	(NOT-BLOCKED card39 S)
+	(NOT-BLOCKED card39 N)
+
+	(NOT-BLOCKED card38 W)
+	(NOT-BLOCKED card38 S)
+	(NOT-BLOCKED card38 E)
+
+	(NOT-BLOCKED card37 E)
+	(NOT-BLOCKED card37 N)
+
+	(NOT-BLOCKED card36 E)
+	(NOT-BLOCKED card36 N)
+
+	(NOT-BLOCKED card35 W)
+	(NOT-BLOCKED card35 N)
+
+	(NOT-BLOCKED card34 S)
+	(NOT-BLOCKED card34 N)
+
+	(NOT-BLOCKED card33 W)
+	(NOT-BLOCKED card33 E)
+	(NOT-BLOCKED card33 N)
+
+	(NOT-BLOCKED card32 S)
+	(NOT-BLOCKED card32 N)
+
+	(NOT-BLOCKED card31 S)
+	(NOT-BLOCKED card31 E)
+
+	(NOT-BLOCKED card30 E)
+	(NOT-BLOCKED card30 N)
+
+	(NOT-BLOCKED card29 W)
+	(NOT-BLOCKED card29 N)
+
+	(NOT-BLOCKED card28 W)
+	(NOT-BLOCKED card28 N)
+
+	(NOT-BLOCKED card27 S)
+	(NOT-BLOCKED card27 N)
+
+	(NOT-BLOCKED card26 W)
+	(NOT-BLOCKED card26 N)
+
+	(NOT-BLOCKED card25 W)
+	(NOT-BLOCKED card25 E)
+
+	(NOT-BLOCKED card24 E)
+	(NOT-BLOCKED card24 N)
+
+	(NOT-BLOCKED card23 W)
+	(NOT-BLOCKED card23 N)
+
+	(NOT-BLOCKED card22 W)
+	(NOT-BLOCKED card22 S)
+
+	(NOT-BLOCKED card21 E)
+	(NOT-BLOCKED card21 N)
+
+	(NOT-BLOCKED card20 W)
+	(NOT-BLOCKED card20 S)
+
+	(NOT-BLOCKED card19 W)
+	(NOT-BLOCKED card19 E)
+
+	(NOT-BLOCKED card18 E)
+	(NOT-BLOCKED card18 N)
+
+	(NOT-BLOCKED card17 W)
+	(NOT-BLOCKED card17 N)
+
+	(NOT-BLOCKED card16 S)
+	(NOT-BLOCKED card16 E)
+
+	(NOT-BLOCKED card15 E)
+	(NOT-BLOCKED card15 N)
+
+	(NOT-BLOCKED card14 W)
+	(NOT-BLOCKED card14 S)
+	(NOT-BLOCKED card14 E)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 S)
+	(NOT-BLOCKED card13 E)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 W)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 S)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 E)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 S)
+	(NOT-BLOCKED card9 E)
+
+	(NOT-BLOCKED card8 W)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 E)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 S)
+	(NOT-BLOCKED card6 N)
+
+	(NOT-BLOCKED card5 W)
+	(NOT-BLOCKED card5 S)
+	(NOT-BLOCKED card5 E)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 S)
+	(NOT-BLOCKED card4 E)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 E)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 E)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 S)
+	(NOT-BLOCKED card1 E)
+
+	(NOT-BLOCKED card0 W)
+	(NOT-BLOCKED card0 S)
+
+	(MAX-POS pos6)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+	(NEXT pos6 pos5)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card9 pos2 pos0)
+	(card-at card45 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card47 pos5 pos0)
+	(card-at card6 pos6 pos0)
+	(card-at card8 pos0 pos1)
+	(card-at card16 pos1 pos1)
+	(card-at card10 pos2 pos1)
+	(card-at card3 pos3 pos1)
+	(card-at card12 pos4 pos1)
+	(card-at card5 pos5 pos1)
+	(card-at card7 pos6 pos1)
+	(card-at card15 pos0 pos2)
+	(card-at card23 pos1 pos2)
+	(card-at card17 pos2 pos2)
+	(card-at card11 pos3 pos2)
+	(card-at card19 pos4 pos2)
+	(card-at card13 pos5 pos2)
+	(card-at card14 pos6 pos2)
+	(card-at card27 pos0 pos3)
+	(card-at card21 pos1 pos3)
+	(card-at card22 pos2 pos3)
+	(card-at card18 pos3 pos3)
+	(card-at card24 pos4 pos3)
+	(card-at card20 pos5 pos3)
+	(card-at card26 pos6 pos3)
+	(card-at card28 pos0 pos4)
+	(card-at card29 pos1 pos4)
+	(card-at card37 pos2 pos4)
+	(card-at card30 pos3 pos4)
+	(card-at card32 pos4 pos4)
+	(card-at card25 pos5 pos4)
+	(card-at card34 pos6 pos4)
+	(card-at card35 pos0 pos5)
+	(card-at card36 pos1 pos5)
+	(card-at card44 pos2 pos5)
+	(card-at card31 pos3 pos5)
+	(card-at card39 pos4 pos5)
+	(card-at card33 pos5 pos5)
+	(card-at card41 pos6 pos5)
+	(card-at card42 pos0 pos6)
+	(card-at card43 pos1 pos6)
+	(card-at card2 pos2 pos6)
+	(card-at card38 pos3 pos6)
+	(card-at card46 pos4 pos6)
+	(card-at card40 pos5 pos6)
+	(card-at card48 pos6 pos6)
+
+	(BLOCKED card0 N)
+	(BLOCKED card0 E)
+
+	(BLOCKED card1 N)
+
+	(BLOCKED card9 N)
+	(BLOCKED card9 W)
+
+	(BLOCKED card45 N)
+
+	(BLOCKED card4 N)
+
+	(BLOCKED card47 E)
+	(BLOCKED card47 W)
+
+	(BLOCKED card6 E)
+	(BLOCKED card6 W)
+
+	(BLOCKED card8 E)
+	(BLOCKED card8 S)
+
+	(BLOCKED card16 N)
+	(BLOCKED card16 W)
+
+	(BLOCKED card10 S)
+	(BLOCKED card10 W)
+
+	(BLOCKED card3 N)
+	(BLOCKED card3 S)
+
+	(BLOCKED card12 E)
+	(BLOCKED card12 S)
+
+
+	(BLOCKED card7 S)
+	(BLOCKED card7 W)
+
+	(BLOCKED card15 S)
+	(BLOCKED card15 W)
+
+	(BLOCKED card23 E)
+	(BLOCKED card23 S)
+
+	(BLOCKED card17 E)
+	(BLOCKED card17 S)
+
+	(BLOCKED card11 E)
+	(BLOCKED card11 W)
+
+	(BLOCKED card19 N)
+	(BLOCKED card19 S)
+
+
+	(BLOCKED card14 N)
+
+	(BLOCKED card27 E)
+	(BLOCKED card27 W)
+
+	(BLOCKED card21 S)
+	(BLOCKED card21 W)
+
+	(BLOCKED card22 N)
+	(BLOCKED card22 E)
+
+	(BLOCKED card18 S)
+	(BLOCKED card18 W)
+
+	(BLOCKED card24 S)
+	(BLOCKED card24 W)
+
+	(BLOCKED card20 N)
+	(BLOCKED card20 E)
+
+	(BLOCKED card26 E)
+	(BLOCKED card26 S)
+
+	(BLOCKED card28 E)
+	(BLOCKED card28 S)
+
+	(BLOCKED card29 E)
+	(BLOCKED card29 S)
+
+	(BLOCKED card37 S)
+	(BLOCKED card37 W)
+
+	(BLOCKED card30 S)
+	(BLOCKED card30 W)
+
+	(BLOCKED card32 E)
+	(BLOCKED card32 W)
+
+	(BLOCKED card25 N)
+	(BLOCKED card25 S)
+
+	(BLOCKED card34 E)
+	(BLOCKED card34 W)
+
+	(BLOCKED card35 E)
+	(BLOCKED card35 S)
+
+	(BLOCKED card36 S)
+	(BLOCKED card36 W)
+
+	(BLOCKED card44 N)
+	(BLOCKED card44 W)
+
+	(BLOCKED card31 N)
+	(BLOCKED card31 W)
+
+	(BLOCKED card39 E)
+	(BLOCKED card39 W)
+
+	(BLOCKED card33 S)
+
+	(BLOCKED card41 E)
+	(BLOCKED card41 W)
+
+	(BLOCKED card42 E)
+	(BLOCKED card42 W)
+
+	(BLOCKED card43 E)
+	(BLOCKED card43 W)
+
+	(BLOCKED card2 N)
+	(BLOCKED card2 S)
+
+	(BLOCKED card38 N)
+
+	(BLOCKED card46 N)
+	(BLOCKED card46 E)
+
+	(BLOCKED card40 N)
+	(BLOCKED card40 W)
+
+	(BLOCKED card48 W)
+
+
+	(robot-at card0)
+
+	(not-robot-at card48)
+	(not-robot-at card47)
+	(not-robot-at card46)
+	(not-robot-at card45)
+	(not-robot-at card44)
+	(not-robot-at card43)
+	(not-robot-at card42)
+	(not-robot-at card41)
+	(not-robot-at card40)
+	(not-robot-at card39)
+	(not-robot-at card38)
+	(not-robot-at card37)
+	(not-robot-at card36)
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/SAT/p15.pddl
+++ b/labyrinth/SAT/p15.pddl
@@ -1,0 +1,425 @@
+;; Generated with seed: 1319, size: 7, num-rotations: 8
+(define (problem labyrinth-size-7-rotations-8-seed-1319)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5 pos6  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35 card36 card37 card38 card39 card40 card41 card42 card43 card44 card45 card46 card47 card48  - card
+)
+(:init
+	(NOT-BLOCKED card48 W)
+	(NOT-BLOCKED card48 S)
+	(NOT-BLOCKED card48 E)
+
+	(NOT-BLOCKED card47 E)
+	(NOT-BLOCKED card47 N)
+
+	(NOT-BLOCKED card46 S)
+	(NOT-BLOCKED card46 E)
+
+	(NOT-BLOCKED card45 W)
+	(NOT-BLOCKED card45 E)
+
+	(NOT-BLOCKED card44 S)
+	(NOT-BLOCKED card44 E)
+	(NOT-BLOCKED card44 N)
+
+	(NOT-BLOCKED card43 S)
+	(NOT-BLOCKED card43 N)
+
+	(NOT-BLOCKED card42 E)
+	(NOT-BLOCKED card42 N)
+
+	(NOT-BLOCKED card41 E)
+	(NOT-BLOCKED card41 N)
+
+	(NOT-BLOCKED card40 W)
+	(NOT-BLOCKED card40 S)
+	(NOT-BLOCKED card40 N)
+
+	(NOT-BLOCKED card39 E)
+	(NOT-BLOCKED card39 N)
+
+	(NOT-BLOCKED card38 W)
+	(NOT-BLOCKED card38 N)
+
+	(NOT-BLOCKED card37 E)
+	(NOT-BLOCKED card37 N)
+
+	(NOT-BLOCKED card36 W)
+	(NOT-BLOCKED card36 S)
+
+	(NOT-BLOCKED card35 W)
+	(NOT-BLOCKED card35 N)
+
+	(NOT-BLOCKED card34 W)
+	(NOT-BLOCKED card34 S)
+	(NOT-BLOCKED card34 E)
+	(NOT-BLOCKED card34 N)
+
+	(NOT-BLOCKED card33 E)
+	(NOT-BLOCKED card33 N)
+
+	(NOT-BLOCKED card32 W)
+	(NOT-BLOCKED card32 S)
+
+	(NOT-BLOCKED card31 S)
+	(NOT-BLOCKED card31 E)
+
+	(NOT-BLOCKED card30 W)
+	(NOT-BLOCKED card30 S)
+	(NOT-BLOCKED card30 N)
+
+	(NOT-BLOCKED card29 W)
+	(NOT-BLOCKED card29 E)
+
+	(NOT-BLOCKED card28 W)
+	(NOT-BLOCKED card28 E)
+	(NOT-BLOCKED card28 N)
+
+	(NOT-BLOCKED card27 S)
+	(NOT-BLOCKED card27 N)
+
+	(NOT-BLOCKED card26 W)
+	(NOT-BLOCKED card26 S)
+	(NOT-BLOCKED card26 N)
+
+	(NOT-BLOCKED card25 S)
+	(NOT-BLOCKED card25 N)
+
+	(NOT-BLOCKED card24 W)
+	(NOT-BLOCKED card24 E)
+
+	(NOT-BLOCKED card23 E)
+	(NOT-BLOCKED card23 N)
+
+	(NOT-BLOCKED card22 S)
+	(NOT-BLOCKED card22 N)
+
+	(NOT-BLOCKED card21 S)
+	(NOT-BLOCKED card21 N)
+
+	(NOT-BLOCKED card20 W)
+	(NOT-BLOCKED card20 S)
+
+	(NOT-BLOCKED card19 S)
+	(NOT-BLOCKED card19 E)
+
+	(NOT-BLOCKED card18 S)
+	(NOT-BLOCKED card18 N)
+
+	(NOT-BLOCKED card17 W)
+	(NOT-BLOCKED card17 E)
+
+	(NOT-BLOCKED card16 E)
+	(NOT-BLOCKED card16 N)
+
+	(NOT-BLOCKED card15 S)
+	(NOT-BLOCKED card15 E)
+
+	(NOT-BLOCKED card14 S)
+	(NOT-BLOCKED card14 E)
+	(NOT-BLOCKED card14 N)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 S)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 S)
+	(NOT-BLOCKED card12 E)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 E)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 E)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 W)
+	(NOT-BLOCKED card9 S)
+	(NOT-BLOCKED card9 E)
+
+	(NOT-BLOCKED card8 W)
+	(NOT-BLOCKED card8 E)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 W)
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 E)
+
+	(NOT-BLOCKED card6 W)
+	(NOT-BLOCKED card6 N)
+
+	(NOT-BLOCKED card5 W)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 E)
+
+	(NOT-BLOCKED card3 S)
+	(NOT-BLOCKED card3 N)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 S)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 S)
+
+	(NOT-BLOCKED card0 S)
+	(NOT-BLOCKED card0 E)
+
+	(MAX-POS pos6)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+	(NEXT pos6 pos5)
+
+	(card-at card0 pos0 pos0)
+	(card-at card43 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card47 pos5 pos0)
+	(card-at card6 pos6 pos0)
+	(card-at card7 pos0 pos1)
+	(card-at card1 pos1 pos1)
+	(card-at card9 pos2 pos1)
+	(card-at card10 pos3 pos1)
+	(card-at card11 pos4 pos1)
+	(card-at card5 pos5 pos1)
+	(card-at card13 pos6 pos1)
+	(card-at card20 pos0 pos2)
+	(card-at card14 pos1 pos2)
+	(card-at card8 pos2 pos2)
+	(card-at card16 pos3 pos2)
+	(card-at card17 pos4 pos2)
+	(card-at card18 pos5 pos2)
+	(card-at card12 pos6 pos2)
+	(card-at card21 pos0 pos3)
+	(card-at card15 pos1 pos3)
+	(card-at card23 pos2 pos3)
+	(card-at card24 pos3 pos3)
+	(card-at card25 pos4 pos3)
+	(card-at card19 pos5 pos3)
+	(card-at card27 pos6 pos3)
+	(card-at card29 pos0 pos4)
+	(card-at card22 pos1 pos4)
+	(card-at card31 pos2 pos4)
+	(card-at card32 pos3 pos4)
+	(card-at card33 pos4 pos4)
+	(card-at card26 pos5 pos4)
+	(card-at card28 pos6 pos4)
+	(card-at card35 pos0 pos5)
+	(card-at card30 pos1 pos5)
+	(card-at card37 pos2 pos5)
+	(card-at card38 pos3 pos5)
+	(card-at card39 pos4 pos5)
+	(card-at card34 pos5 pos5)
+	(card-at card41 pos6 pos5)
+	(card-at card42 pos0 pos6)
+	(card-at card36 pos1 pos6)
+	(card-at card44 pos2 pos6)
+	(card-at card45 pos3 pos6)
+	(card-at card46 pos4 pos6)
+	(card-at card40 pos5 pos6)
+	(card-at card48 pos6 pos6)
+
+	(BLOCKED card0 N)
+	(BLOCKED card0 W)
+
+	(BLOCKED card43 E)
+	(BLOCKED card43 W)
+
+	(BLOCKED card2 N)
+	(BLOCKED card2 E)
+
+	(BLOCKED card3 E)
+	(BLOCKED card3 W)
+
+	(BLOCKED card4 N)
+	(BLOCKED card4 S)
+
+	(BLOCKED card47 S)
+	(BLOCKED card47 W)
+
+	(BLOCKED card6 E)
+	(BLOCKED card6 S)
+
+	(BLOCKED card7 N)
+
+	(BLOCKED card1 N)
+	(BLOCKED card1 E)
+
+	(BLOCKED card9 N)
+
+	(BLOCKED card10 S)
+	(BLOCKED card10 W)
+
+	(BLOCKED card11 S)
+	(BLOCKED card11 W)
+
+	(BLOCKED card5 E)
+	(BLOCKED card5 S)
+
+	(BLOCKED card13 E)
+
+	(BLOCKED card20 N)
+	(BLOCKED card20 E)
+
+	(BLOCKED card14 W)
+
+	(BLOCKED card8 S)
+
+	(BLOCKED card16 S)
+	(BLOCKED card16 W)
+
+	(BLOCKED card17 N)
+	(BLOCKED card17 S)
+
+	(BLOCKED card18 E)
+	(BLOCKED card18 W)
+
+	(BLOCKED card12 W)
+
+	(BLOCKED card21 E)
+	(BLOCKED card21 W)
+
+	(BLOCKED card15 N)
+	(BLOCKED card15 W)
+
+	(BLOCKED card23 S)
+	(BLOCKED card23 W)
+
+	(BLOCKED card24 N)
+	(BLOCKED card24 S)
+
+	(BLOCKED card25 E)
+	(BLOCKED card25 W)
+
+	(BLOCKED card19 N)
+	(BLOCKED card19 W)
+
+	(BLOCKED card27 E)
+	(BLOCKED card27 W)
+
+	(BLOCKED card29 N)
+	(BLOCKED card29 S)
+
+	(BLOCKED card22 E)
+	(BLOCKED card22 W)
+
+	(BLOCKED card31 N)
+	(BLOCKED card31 W)
+
+	(BLOCKED card32 N)
+	(BLOCKED card32 E)
+
+	(BLOCKED card33 S)
+	(BLOCKED card33 W)
+
+	(BLOCKED card26 E)
+
+	(BLOCKED card28 S)
+
+	(BLOCKED card35 E)
+	(BLOCKED card35 S)
+
+	(BLOCKED card30 E)
+
+	(BLOCKED card37 S)
+	(BLOCKED card37 W)
+
+	(BLOCKED card38 E)
+	(BLOCKED card38 S)
+
+	(BLOCKED card39 S)
+	(BLOCKED card39 W)
+
+
+	(BLOCKED card41 S)
+	(BLOCKED card41 W)
+
+	(BLOCKED card42 S)
+	(BLOCKED card42 W)
+
+	(BLOCKED card36 N)
+	(BLOCKED card36 E)
+
+	(BLOCKED card44 W)
+
+	(BLOCKED card45 N)
+	(BLOCKED card45 S)
+
+	(BLOCKED card46 N)
+	(BLOCKED card46 W)
+
+	(BLOCKED card40 E)
+
+	(BLOCKED card48 N)
+
+
+	(robot-at card0)
+
+	(not-robot-at card48)
+	(not-robot-at card47)
+	(not-robot-at card46)
+	(not-robot-at card45)
+	(not-robot-at card44)
+	(not-robot-at card43)
+	(not-robot-at card42)
+	(not-robot-at card41)
+	(not-robot-at card40)
+	(not-robot-at card39)
+	(not-robot-at card38)
+	(not-robot-at card37)
+	(not-robot-at card36)
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/SAT/p16.pddl
+++ b/labyrinth/SAT/p16.pddl
@@ -1,0 +1,546 @@
+;; Generated with seed: 1321, size: 8, num-rotations: 1
+(define (problem labyrinth-size-8-rotations-1-seed-1321)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5 pos6 pos7  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35 card36 card37 card38 card39 card40 card41 card42 card43 card44 card45 card46 card47 card48 card49 card50 card51 card52 card53 card54 card55 card56 card57 card58 card59 card60 card61 card62 card63  - card
+)
+(:init
+	(NOT-BLOCKED card63 W)
+	(NOT-BLOCKED card63 S)
+
+	(NOT-BLOCKED card62 W)
+	(NOT-BLOCKED card62 E)
+
+	(NOT-BLOCKED card61 W)
+	(NOT-BLOCKED card61 E)
+
+	(NOT-BLOCKED card60 W)
+	(NOT-BLOCKED card60 E)
+	(NOT-BLOCKED card60 N)
+
+	(NOT-BLOCKED card59 W)
+	(NOT-BLOCKED card59 E)
+
+	(NOT-BLOCKED card58 W)
+	(NOT-BLOCKED card58 E)
+
+	(NOT-BLOCKED card57 W)
+	(NOT-BLOCKED card57 S)
+	(NOT-BLOCKED card57 E)
+
+	(NOT-BLOCKED card56 E)
+	(NOT-BLOCKED card56 N)
+
+	(NOT-BLOCKED card55 W)
+	(NOT-BLOCKED card55 E)
+
+	(NOT-BLOCKED card54 S)
+	(NOT-BLOCKED card54 E)
+
+	(NOT-BLOCKED card53 W)
+	(NOT-BLOCKED card53 E)
+
+	(NOT-BLOCKED card52 S)
+	(NOT-BLOCKED card52 E)
+
+	(NOT-BLOCKED card51 S)
+	(NOT-BLOCKED card51 E)
+
+	(NOT-BLOCKED card50 W)
+	(NOT-BLOCKED card50 S)
+
+	(NOT-BLOCKED card49 E)
+	(NOT-BLOCKED card49 N)
+
+	(NOT-BLOCKED card48 S)
+	(NOT-BLOCKED card48 N)
+
+	(NOT-BLOCKED card47 E)
+	(NOT-BLOCKED card47 N)
+
+	(NOT-BLOCKED card46 W)
+	(NOT-BLOCKED card46 E)
+	(NOT-BLOCKED card46 N)
+
+	(NOT-BLOCKED card45 S)
+	(NOT-BLOCKED card45 E)
+
+	(NOT-BLOCKED card44 S)
+	(NOT-BLOCKED card44 E)
+
+	(NOT-BLOCKED card43 W)
+	(NOT-BLOCKED card43 S)
+
+	(NOT-BLOCKED card42 W)
+	(NOT-BLOCKED card42 E)
+
+	(NOT-BLOCKED card41 W)
+	(NOT-BLOCKED card41 S)
+
+	(NOT-BLOCKED card40 S)
+	(NOT-BLOCKED card40 N)
+
+	(NOT-BLOCKED card39 W)
+	(NOT-BLOCKED card39 E)
+
+	(NOT-BLOCKED card38 W)
+	(NOT-BLOCKED card38 S)
+
+	(NOT-BLOCKED card37 S)
+	(NOT-BLOCKED card37 E)
+
+	(NOT-BLOCKED card36 S)
+	(NOT-BLOCKED card36 N)
+
+	(NOT-BLOCKED card35 W)
+	(NOT-BLOCKED card35 S)
+	(NOT-BLOCKED card35 N)
+
+	(NOT-BLOCKED card34 W)
+	(NOT-BLOCKED card34 N)
+
+	(NOT-BLOCKED card33 W)
+	(NOT-BLOCKED card33 S)
+	(NOT-BLOCKED card33 N)
+
+	(NOT-BLOCKED card32 W)
+	(NOT-BLOCKED card32 S)
+	(NOT-BLOCKED card32 E)
+	(NOT-BLOCKED card32 N)
+
+	(NOT-BLOCKED card31 S)
+	(NOT-BLOCKED card31 N)
+
+	(NOT-BLOCKED card30 W)
+	(NOT-BLOCKED card30 S)
+	(NOT-BLOCKED card30 E)
+	(NOT-BLOCKED card30 N)
+
+	(NOT-BLOCKED card29 W)
+	(NOT-BLOCKED card29 S)
+	(NOT-BLOCKED card29 N)
+
+	(NOT-BLOCKED card28 E)
+	(NOT-BLOCKED card28 N)
+
+	(NOT-BLOCKED card27 W)
+	(NOT-BLOCKED card27 S)
+	(NOT-BLOCKED card27 E)
+
+	(NOT-BLOCKED card26 W)
+	(NOT-BLOCKED card26 S)
+
+	(NOT-BLOCKED card25 W)
+	(NOT-BLOCKED card25 S)
+	(NOT-BLOCKED card25 E)
+	(NOT-BLOCKED card25 N)
+
+	(NOT-BLOCKED card24 S)
+	(NOT-BLOCKED card24 N)
+
+	(NOT-BLOCKED card23 W)
+	(NOT-BLOCKED card23 E)
+	(NOT-BLOCKED card23 N)
+
+	(NOT-BLOCKED card22 W)
+	(NOT-BLOCKED card22 E)
+
+	(NOT-BLOCKED card21 W)
+	(NOT-BLOCKED card21 S)
+
+	(NOT-BLOCKED card20 W)
+	(NOT-BLOCKED card20 S)
+	(NOT-BLOCKED card20 N)
+
+	(NOT-BLOCKED card19 W)
+	(NOT-BLOCKED card19 S)
+	(NOT-BLOCKED card19 E)
+
+	(NOT-BLOCKED card18 W)
+	(NOT-BLOCKED card18 S)
+	(NOT-BLOCKED card18 E)
+
+	(NOT-BLOCKED card17 W)
+	(NOT-BLOCKED card17 E)
+	(NOT-BLOCKED card17 N)
+
+	(NOT-BLOCKED card16 S)
+	(NOT-BLOCKED card16 N)
+
+	(NOT-BLOCKED card15 W)
+	(NOT-BLOCKED card15 E)
+	(NOT-BLOCKED card15 N)
+
+	(NOT-BLOCKED card14 S)
+	(NOT-BLOCKED card14 E)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 E)
+
+	(NOT-BLOCKED card12 S)
+	(NOT-BLOCKED card12 E)
+
+	(NOT-BLOCKED card11 W)
+	(NOT-BLOCKED card11 S)
+	(NOT-BLOCKED card11 E)
+
+	(NOT-BLOCKED card10 S)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 S)
+	(NOT-BLOCKED card9 E)
+
+	(NOT-BLOCKED card8 W)
+	(NOT-BLOCKED card8 S)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 W)
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 E)
+
+	(NOT-BLOCKED card6 E)
+	(NOT-BLOCKED card6 N)
+
+	(NOT-BLOCKED card5 S)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 S)
+	(NOT-BLOCKED card4 E)
+
+	(NOT-BLOCKED card3 E)
+	(NOT-BLOCKED card3 N)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 N)
+
+	(NOT-BLOCKED card1 E)
+	(NOT-BLOCKED card1 N)
+
+	(NOT-BLOCKED card0 W)
+	(NOT-BLOCKED card0 S)
+	(NOT-BLOCKED card0 E)
+
+	(MAX-POS pos7)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+	(NEXT pos6 pos5)
+	(NEXT pos7 pos6)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card5 pos5 pos0)
+	(card-at card6 pos6 pos0)
+	(card-at card7 pos7 pos0)
+	(card-at card8 pos0 pos1)
+	(card-at card9 pos1 pos1)
+	(card-at card10 pos2 pos1)
+	(card-at card11 pos3 pos1)
+	(card-at card12 pos4 pos1)
+	(card-at card13 pos5 pos1)
+	(card-at card14 pos6 pos1)
+	(card-at card15 pos7 pos1)
+	(card-at card23 pos0 pos2)
+	(card-at card16 pos1 pos2)
+	(card-at card17 pos2 pos2)
+	(card-at card18 pos3 pos2)
+	(card-at card19 pos4 pos2)
+	(card-at card20 pos5 pos2)
+	(card-at card21 pos6 pos2)
+	(card-at card22 pos7 pos2)
+	(card-at card24 pos0 pos3)
+	(card-at card25 pos1 pos3)
+	(card-at card26 pos2 pos3)
+	(card-at card27 pos3 pos3)
+	(card-at card28 pos4 pos3)
+	(card-at card29 pos5 pos3)
+	(card-at card30 pos6 pos3)
+	(card-at card31 pos7 pos3)
+	(card-at card32 pos0 pos4)
+	(card-at card33 pos1 pos4)
+	(card-at card34 pos2 pos4)
+	(card-at card35 pos3 pos4)
+	(card-at card36 pos4 pos4)
+	(card-at card37 pos5 pos4)
+	(card-at card38 pos6 pos4)
+	(card-at card39 pos7 pos4)
+	(card-at card40 pos0 pos5)
+	(card-at card41 pos1 pos5)
+	(card-at card42 pos2 pos5)
+	(card-at card43 pos3 pos5)
+	(card-at card44 pos4 pos5)
+	(card-at card45 pos5 pos5)
+	(card-at card46 pos6 pos5)
+	(card-at card47 pos7 pos5)
+	(card-at card48 pos0 pos6)
+	(card-at card49 pos1 pos6)
+	(card-at card50 pos2 pos6)
+	(card-at card51 pos3 pos6)
+	(card-at card52 pos4 pos6)
+	(card-at card53 pos5 pos6)
+	(card-at card54 pos6 pos6)
+	(card-at card55 pos7 pos6)
+	(card-at card56 pos0 pos7)
+	(card-at card57 pos1 pos7)
+	(card-at card58 pos2 pos7)
+	(card-at card59 pos3 pos7)
+	(card-at card60 pos4 pos7)
+	(card-at card61 pos5 pos7)
+	(card-at card62 pos6 pos7)
+	(card-at card63 pos7 pos7)
+
+	(BLOCKED card0 N)
+
+	(BLOCKED card1 S)
+	(BLOCKED card1 W)
+
+	(BLOCKED card2 E)
+	(BLOCKED card2 S)
+
+	(BLOCKED card3 S)
+	(BLOCKED card3 W)
+
+	(BLOCKED card4 N)
+
+	(BLOCKED card5 E)
+	(BLOCKED card5 W)
+
+	(BLOCKED card6 S)
+	(BLOCKED card6 W)
+
+	(BLOCKED card7 N)
+
+	(BLOCKED card8 E)
+
+	(BLOCKED card9 N)
+	(BLOCKED card9 W)
+
+	(BLOCKED card10 E)
+	(BLOCKED card10 W)
+
+	(BLOCKED card11 N)
+
+	(BLOCKED card12 N)
+	(BLOCKED card12 W)
+
+	(BLOCKED card13 N)
+	(BLOCKED card13 S)
+
+	(BLOCKED card14 N)
+	(BLOCKED card14 W)
+
+	(BLOCKED card15 S)
+
+	(BLOCKED card23 S)
+
+	(BLOCKED card16 E)
+	(BLOCKED card16 W)
+
+	(BLOCKED card17 S)
+
+	(BLOCKED card18 N)
+
+	(BLOCKED card19 N)
+
+	(BLOCKED card20 E)
+
+	(BLOCKED card21 N)
+	(BLOCKED card21 E)
+
+	(BLOCKED card22 N)
+	(BLOCKED card22 S)
+
+	(BLOCKED card24 E)
+	(BLOCKED card24 W)
+
+
+	(BLOCKED card26 N)
+	(BLOCKED card26 E)
+
+	(BLOCKED card27 N)
+
+	(BLOCKED card28 S)
+	(BLOCKED card28 W)
+
+	(BLOCKED card29 E)
+
+
+	(BLOCKED card31 E)
+	(BLOCKED card31 W)
+
+
+	(BLOCKED card33 E)
+
+	(BLOCKED card34 E)
+	(BLOCKED card34 S)
+
+	(BLOCKED card35 E)
+
+	(BLOCKED card36 E)
+	(BLOCKED card36 W)
+
+	(BLOCKED card37 N)
+	(BLOCKED card37 W)
+
+	(BLOCKED card38 N)
+	(BLOCKED card38 E)
+
+	(BLOCKED card39 N)
+	(BLOCKED card39 S)
+
+	(BLOCKED card40 E)
+	(BLOCKED card40 W)
+
+	(BLOCKED card41 N)
+	(BLOCKED card41 E)
+
+	(BLOCKED card42 N)
+	(BLOCKED card42 S)
+
+	(BLOCKED card43 N)
+	(BLOCKED card43 E)
+
+	(BLOCKED card44 N)
+	(BLOCKED card44 W)
+
+	(BLOCKED card45 N)
+	(BLOCKED card45 W)
+
+	(BLOCKED card46 S)
+
+	(BLOCKED card47 S)
+	(BLOCKED card47 W)
+
+	(BLOCKED card48 E)
+	(BLOCKED card48 W)
+
+	(BLOCKED card49 S)
+	(BLOCKED card49 W)
+
+	(BLOCKED card50 N)
+	(BLOCKED card50 E)
+
+	(BLOCKED card51 N)
+	(BLOCKED card51 W)
+
+	(BLOCKED card52 N)
+	(BLOCKED card52 W)
+
+	(BLOCKED card53 N)
+	(BLOCKED card53 S)
+
+	(BLOCKED card54 N)
+	(BLOCKED card54 W)
+
+	(BLOCKED card55 N)
+	(BLOCKED card55 S)
+
+	(BLOCKED card56 S)
+	(BLOCKED card56 W)
+
+	(BLOCKED card57 N)
+
+	(BLOCKED card58 N)
+	(BLOCKED card58 S)
+
+	(BLOCKED card59 N)
+	(BLOCKED card59 S)
+
+	(BLOCKED card60 S)
+
+	(BLOCKED card61 N)
+	(BLOCKED card61 S)
+
+	(BLOCKED card62 N)
+	(BLOCKED card62 S)
+
+	(BLOCKED card63 N)
+	(BLOCKED card63 E)
+
+
+	(robot-at card0)
+
+	(not-robot-at card63)
+	(not-robot-at card62)
+	(not-robot-at card61)
+	(not-robot-at card60)
+	(not-robot-at card59)
+	(not-robot-at card58)
+	(not-robot-at card57)
+	(not-robot-at card56)
+	(not-robot-at card55)
+	(not-robot-at card54)
+	(not-robot-at card53)
+	(not-robot-at card52)
+	(not-robot-at card51)
+	(not-robot-at card50)
+	(not-robot-at card49)
+	(not-robot-at card48)
+	(not-robot-at card47)
+	(not-robot-at card46)
+	(not-robot-at card45)
+	(not-robot-at card44)
+	(not-robot-at card43)
+	(not-robot-at card42)
+	(not-robot-at card41)
+	(not-robot-at card40)
+	(not-robot-at card39)
+	(not-robot-at card38)
+	(not-robot-at card37)
+	(not-robot-at card36)
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/SAT/p17.pddl
+++ b/labyrinth/SAT/p17.pddl
@@ -1,0 +1,546 @@
+;; Generated with seed: 1327, size: 8, num-rotations: 2
+(define (problem labyrinth-size-8-rotations-2-seed-1327)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5 pos6 pos7  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35 card36 card37 card38 card39 card40 card41 card42 card43 card44 card45 card46 card47 card48 card49 card50 card51 card52 card53 card54 card55 card56 card57 card58 card59 card60 card61 card62 card63  - card
+)
+(:init
+	(NOT-BLOCKED card63 S)
+	(NOT-BLOCKED card63 N)
+
+	(NOT-BLOCKED card62 W)
+	(NOT-BLOCKED card62 N)
+
+	(NOT-BLOCKED card61 E)
+	(NOT-BLOCKED card61 N)
+
+	(NOT-BLOCKED card60 W)
+	(NOT-BLOCKED card60 E)
+	(NOT-BLOCKED card60 N)
+
+	(NOT-BLOCKED card59 W)
+	(NOT-BLOCKED card59 S)
+
+	(NOT-BLOCKED card58 W)
+	(NOT-BLOCKED card58 S)
+	(NOT-BLOCKED card58 N)
+
+	(NOT-BLOCKED card57 S)
+	(NOT-BLOCKED card57 E)
+
+	(NOT-BLOCKED card56 S)
+	(NOT-BLOCKED card56 N)
+
+	(NOT-BLOCKED card55 S)
+	(NOT-BLOCKED card55 N)
+
+	(NOT-BLOCKED card54 W)
+	(NOT-BLOCKED card54 S)
+	(NOT-BLOCKED card54 E)
+	(NOT-BLOCKED card54 N)
+
+	(NOT-BLOCKED card53 S)
+	(NOT-BLOCKED card53 E)
+	(NOT-BLOCKED card53 N)
+
+	(NOT-BLOCKED card52 W)
+	(NOT-BLOCKED card52 E)
+
+	(NOT-BLOCKED card51 W)
+	(NOT-BLOCKED card51 S)
+	(NOT-BLOCKED card51 N)
+
+	(NOT-BLOCKED card50 E)
+	(NOT-BLOCKED card50 N)
+
+	(NOT-BLOCKED card49 S)
+	(NOT-BLOCKED card49 E)
+	(NOT-BLOCKED card49 N)
+
+	(NOT-BLOCKED card48 W)
+	(NOT-BLOCKED card48 E)
+
+	(NOT-BLOCKED card47 W)
+	(NOT-BLOCKED card47 S)
+	(NOT-BLOCKED card47 N)
+
+	(NOT-BLOCKED card46 W)
+	(NOT-BLOCKED card46 E)
+	(NOT-BLOCKED card46 N)
+
+	(NOT-BLOCKED card45 E)
+	(NOT-BLOCKED card45 N)
+
+	(NOT-BLOCKED card44 W)
+	(NOT-BLOCKED card44 E)
+
+	(NOT-BLOCKED card43 S)
+	(NOT-BLOCKED card43 E)
+	(NOT-BLOCKED card43 N)
+
+	(NOT-BLOCKED card42 S)
+	(NOT-BLOCKED card42 N)
+
+	(NOT-BLOCKED card41 S)
+	(NOT-BLOCKED card41 N)
+
+	(NOT-BLOCKED card40 W)
+	(NOT-BLOCKED card40 E)
+
+	(NOT-BLOCKED card39 W)
+	(NOT-BLOCKED card39 S)
+
+	(NOT-BLOCKED card38 W)
+	(NOT-BLOCKED card38 S)
+	(NOT-BLOCKED card38 N)
+
+	(NOT-BLOCKED card37 W)
+	(NOT-BLOCKED card37 S)
+
+	(NOT-BLOCKED card36 W)
+	(NOT-BLOCKED card36 E)
+	(NOT-BLOCKED card36 N)
+
+	(NOT-BLOCKED card35 W)
+	(NOT-BLOCKED card35 E)
+
+	(NOT-BLOCKED card34 W)
+	(NOT-BLOCKED card34 E)
+
+	(NOT-BLOCKED card33 W)
+	(NOT-BLOCKED card33 E)
+
+	(NOT-BLOCKED card32 W)
+	(NOT-BLOCKED card32 E)
+
+	(NOT-BLOCKED card31 S)
+	(NOT-BLOCKED card31 N)
+
+	(NOT-BLOCKED card30 S)
+	(NOT-BLOCKED card30 E)
+	(NOT-BLOCKED card30 N)
+
+	(NOT-BLOCKED card29 E)
+	(NOT-BLOCKED card29 N)
+
+	(NOT-BLOCKED card28 W)
+	(NOT-BLOCKED card28 N)
+
+	(NOT-BLOCKED card27 W)
+	(NOT-BLOCKED card27 E)
+	(NOT-BLOCKED card27 N)
+
+	(NOT-BLOCKED card26 S)
+	(NOT-BLOCKED card26 E)
+
+	(NOT-BLOCKED card25 W)
+	(NOT-BLOCKED card25 S)
+	(NOT-BLOCKED card25 N)
+
+	(NOT-BLOCKED card24 E)
+	(NOT-BLOCKED card24 N)
+
+	(NOT-BLOCKED card23 E)
+	(NOT-BLOCKED card23 N)
+
+	(NOT-BLOCKED card22 S)
+	(NOT-BLOCKED card22 E)
+	(NOT-BLOCKED card22 N)
+
+	(NOT-BLOCKED card21 W)
+	(NOT-BLOCKED card21 S)
+
+	(NOT-BLOCKED card20 W)
+	(NOT-BLOCKED card20 N)
+
+	(NOT-BLOCKED card19 E)
+	(NOT-BLOCKED card19 N)
+
+	(NOT-BLOCKED card18 W)
+	(NOT-BLOCKED card18 E)
+
+	(NOT-BLOCKED card17 E)
+	(NOT-BLOCKED card17 N)
+
+	(NOT-BLOCKED card16 S)
+	(NOT-BLOCKED card16 E)
+
+	(NOT-BLOCKED card15 W)
+	(NOT-BLOCKED card15 N)
+
+	(NOT-BLOCKED card14 W)
+	(NOT-BLOCKED card14 S)
+	(NOT-BLOCKED card14 N)
+
+	(NOT-BLOCKED card13 E)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 W)
+	(NOT-BLOCKED card12 S)
+
+	(NOT-BLOCKED card11 S)
+	(NOT-BLOCKED card11 E)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 W)
+	(NOT-BLOCKED card10 S)
+
+	(NOT-BLOCKED card9 W)
+	(NOT-BLOCKED card9 S)
+
+	(NOT-BLOCKED card8 S)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 W)
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 W)
+	(NOT-BLOCKED card6 S)
+
+	(NOT-BLOCKED card5 W)
+	(NOT-BLOCKED card5 S)
+	(NOT-BLOCKED card5 E)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 S)
+	(NOT-BLOCKED card4 E)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 E)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 S)
+	(NOT-BLOCKED card2 E)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 S)
+	(NOT-BLOCKED card1 E)
+
+	(NOT-BLOCKED card0 W)
+	(NOT-BLOCKED card0 E)
+	(NOT-BLOCKED card0 N)
+
+	(MAX-POS pos7)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+	(NEXT pos6 pos5)
+	(NEXT pos7 pos6)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card59 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card5 pos5 pos0)
+	(card-at card6 pos6 pos0)
+	(card-at card7 pos7 pos0)
+	(card-at card8 pos0 pos1)
+	(card-at card9 pos1 pos1)
+	(card-at card10 pos2 pos1)
+	(card-at card3 pos3 pos1)
+	(card-at card12 pos4 pos1)
+	(card-at card13 pos5 pos1)
+	(card-at card14 pos6 pos1)
+	(card-at card15 pos7 pos1)
+	(card-at card23 pos0 pos2)
+	(card-at card16 pos1 pos2)
+	(card-at card17 pos2 pos2)
+	(card-at card11 pos3 pos2)
+	(card-at card19 pos4 pos2)
+	(card-at card20 pos5 pos2)
+	(card-at card21 pos6 pos2)
+	(card-at card22 pos7 pos2)
+	(card-at card24 pos0 pos3)
+	(card-at card25 pos1 pos3)
+	(card-at card26 pos2 pos3)
+	(card-at card18 pos3 pos3)
+	(card-at card28 pos4 pos3)
+	(card-at card29 pos5 pos3)
+	(card-at card30 pos6 pos3)
+	(card-at card31 pos7 pos3)
+	(card-at card32 pos0 pos4)
+	(card-at card33 pos1 pos4)
+	(card-at card34 pos2 pos4)
+	(card-at card27 pos3 pos4)
+	(card-at card36 pos4 pos4)
+	(card-at card37 pos5 pos4)
+	(card-at card38 pos6 pos4)
+	(card-at card39 pos7 pos4)
+	(card-at card40 pos0 pos5)
+	(card-at card41 pos1 pos5)
+	(card-at card42 pos2 pos5)
+	(card-at card35 pos3 pos5)
+	(card-at card44 pos4 pos5)
+	(card-at card45 pos5 pos5)
+	(card-at card46 pos6 pos5)
+	(card-at card47 pos7 pos5)
+	(card-at card48 pos0 pos6)
+	(card-at card49 pos1 pos6)
+	(card-at card50 pos2 pos6)
+	(card-at card43 pos3 pos6)
+	(card-at card52 pos4 pos6)
+	(card-at card53 pos5 pos6)
+	(card-at card54 pos6 pos6)
+	(card-at card55 pos7 pos6)
+	(card-at card56 pos0 pos7)
+	(card-at card57 pos1 pos7)
+	(card-at card58 pos2 pos7)
+	(card-at card51 pos3 pos7)
+	(card-at card60 pos4 pos7)
+	(card-at card61 pos5 pos7)
+	(card-at card62 pos6 pos7)
+	(card-at card63 pos7 pos7)
+
+	(BLOCKED card0 S)
+
+	(BLOCKED card1 N)
+
+	(BLOCKED card2 N)
+
+	(BLOCKED card59 N)
+	(BLOCKED card59 E)
+
+	(BLOCKED card4 N)
+
+	(BLOCKED card5 N)
+
+	(BLOCKED card6 N)
+	(BLOCKED card6 E)
+
+	(BLOCKED card7 E)
+
+	(BLOCKED card8 E)
+	(BLOCKED card8 W)
+
+	(BLOCKED card9 N)
+	(BLOCKED card9 E)
+
+	(BLOCKED card10 N)
+	(BLOCKED card10 E)
+
+	(BLOCKED card3 N)
+	(BLOCKED card3 S)
+
+	(BLOCKED card12 N)
+	(BLOCKED card12 E)
+
+	(BLOCKED card13 S)
+	(BLOCKED card13 W)
+
+	(BLOCKED card14 E)
+
+	(BLOCKED card15 E)
+	(BLOCKED card15 S)
+
+	(BLOCKED card23 S)
+	(BLOCKED card23 W)
+
+	(BLOCKED card16 N)
+	(BLOCKED card16 W)
+
+	(BLOCKED card17 S)
+	(BLOCKED card17 W)
+
+	(BLOCKED card11 W)
+
+	(BLOCKED card19 S)
+	(BLOCKED card19 W)
+
+	(BLOCKED card20 E)
+	(BLOCKED card20 S)
+
+	(BLOCKED card21 N)
+	(BLOCKED card21 E)
+
+	(BLOCKED card22 W)
+
+	(BLOCKED card24 S)
+	(BLOCKED card24 W)
+
+	(BLOCKED card25 E)
+
+	(BLOCKED card26 N)
+	(BLOCKED card26 W)
+
+	(BLOCKED card18 N)
+	(BLOCKED card18 S)
+
+	(BLOCKED card28 E)
+	(BLOCKED card28 S)
+
+	(BLOCKED card29 S)
+	(BLOCKED card29 W)
+
+	(BLOCKED card30 W)
+
+	(BLOCKED card31 E)
+	(BLOCKED card31 W)
+
+	(BLOCKED card32 N)
+	(BLOCKED card32 S)
+
+	(BLOCKED card33 N)
+	(BLOCKED card33 S)
+
+	(BLOCKED card34 N)
+	(BLOCKED card34 S)
+
+	(BLOCKED card27 S)
+
+	(BLOCKED card36 S)
+
+	(BLOCKED card37 N)
+	(BLOCKED card37 E)
+
+	(BLOCKED card38 E)
+
+	(BLOCKED card39 N)
+	(BLOCKED card39 E)
+
+	(BLOCKED card40 N)
+	(BLOCKED card40 S)
+
+	(BLOCKED card41 E)
+	(BLOCKED card41 W)
+
+	(BLOCKED card42 E)
+	(BLOCKED card42 W)
+
+	(BLOCKED card35 N)
+	(BLOCKED card35 S)
+
+	(BLOCKED card44 N)
+	(BLOCKED card44 S)
+
+	(BLOCKED card45 S)
+	(BLOCKED card45 W)
+
+	(BLOCKED card46 S)
+
+	(BLOCKED card47 E)
+
+	(BLOCKED card48 N)
+	(BLOCKED card48 S)
+
+	(BLOCKED card49 W)
+
+	(BLOCKED card50 S)
+	(BLOCKED card50 W)
+
+	(BLOCKED card43 W)
+
+	(BLOCKED card52 N)
+	(BLOCKED card52 S)
+
+	(BLOCKED card53 W)
+
+
+	(BLOCKED card55 E)
+	(BLOCKED card55 W)
+
+	(BLOCKED card56 E)
+	(BLOCKED card56 W)
+
+	(BLOCKED card57 N)
+	(BLOCKED card57 W)
+
+	(BLOCKED card58 E)
+
+	(BLOCKED card51 E)
+
+	(BLOCKED card60 S)
+
+	(BLOCKED card61 S)
+	(BLOCKED card61 W)
+
+	(BLOCKED card62 E)
+	(BLOCKED card62 S)
+
+	(BLOCKED card63 E)
+	(BLOCKED card63 W)
+
+
+	(robot-at card0)
+
+	(not-robot-at card63)
+	(not-robot-at card62)
+	(not-robot-at card61)
+	(not-robot-at card60)
+	(not-robot-at card59)
+	(not-robot-at card58)
+	(not-robot-at card57)
+	(not-robot-at card56)
+	(not-robot-at card55)
+	(not-robot-at card54)
+	(not-robot-at card53)
+	(not-robot-at card52)
+	(not-robot-at card51)
+	(not-robot-at card50)
+	(not-robot-at card49)
+	(not-robot-at card48)
+	(not-robot-at card47)
+	(not-robot-at card46)
+	(not-robot-at card45)
+	(not-robot-at card44)
+	(not-robot-at card43)
+	(not-robot-at card42)
+	(not-robot-at card41)
+	(not-robot-at card40)
+	(not-robot-at card39)
+	(not-robot-at card38)
+	(not-robot-at card37)
+	(not-robot-at card36)
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/SAT/p18.pddl
+++ b/labyrinth/SAT/p18.pddl
@@ -1,0 +1,546 @@
+;; Generated with seed: 1361, size: 8, num-rotations: 3
+(define (problem labyrinth-size-8-rotations-3-seed-1361)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5 pos6 pos7  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35 card36 card37 card38 card39 card40 card41 card42 card43 card44 card45 card46 card47 card48 card49 card50 card51 card52 card53 card54 card55 card56 card57 card58 card59 card60 card61 card62 card63  - card
+)
+(:init
+	(NOT-BLOCKED card63 S)
+	(NOT-BLOCKED card63 N)
+
+	(NOT-BLOCKED card62 W)
+	(NOT-BLOCKED card62 S)
+
+	(NOT-BLOCKED card61 S)
+	(NOT-BLOCKED card61 N)
+
+	(NOT-BLOCKED card60 W)
+	(NOT-BLOCKED card60 S)
+	(NOT-BLOCKED card60 E)
+	(NOT-BLOCKED card60 N)
+
+	(NOT-BLOCKED card59 S)
+	(NOT-BLOCKED card59 N)
+
+	(NOT-BLOCKED card58 W)
+	(NOT-BLOCKED card58 S)
+	(NOT-BLOCKED card58 E)
+
+	(NOT-BLOCKED card57 S)
+	(NOT-BLOCKED card57 N)
+
+	(NOT-BLOCKED card56 W)
+	(NOT-BLOCKED card56 E)
+	(NOT-BLOCKED card56 N)
+
+	(NOT-BLOCKED card55 S)
+	(NOT-BLOCKED card55 E)
+	(NOT-BLOCKED card55 N)
+
+	(NOT-BLOCKED card54 W)
+	(NOT-BLOCKED card54 E)
+	(NOT-BLOCKED card54 N)
+
+	(NOT-BLOCKED card53 W)
+	(NOT-BLOCKED card53 E)
+
+	(NOT-BLOCKED card52 E)
+	(NOT-BLOCKED card52 N)
+
+	(NOT-BLOCKED card51 E)
+	(NOT-BLOCKED card51 N)
+
+	(NOT-BLOCKED card50 S)
+	(NOT-BLOCKED card50 N)
+
+	(NOT-BLOCKED card49 W)
+	(NOT-BLOCKED card49 S)
+	(NOT-BLOCKED card49 N)
+
+	(NOT-BLOCKED card48 E)
+	(NOT-BLOCKED card48 N)
+
+	(NOT-BLOCKED card47 W)
+	(NOT-BLOCKED card47 S)
+	(NOT-BLOCKED card47 E)
+
+	(NOT-BLOCKED card46 E)
+	(NOT-BLOCKED card46 N)
+
+	(NOT-BLOCKED card45 W)
+	(NOT-BLOCKED card45 N)
+
+	(NOT-BLOCKED card44 S)
+	(NOT-BLOCKED card44 E)
+
+	(NOT-BLOCKED card43 S)
+	(NOT-BLOCKED card43 E)
+
+	(NOT-BLOCKED card42 S)
+	(NOT-BLOCKED card42 E)
+	(NOT-BLOCKED card42 N)
+
+	(NOT-BLOCKED card41 W)
+	(NOT-BLOCKED card41 N)
+
+	(NOT-BLOCKED card40 E)
+	(NOT-BLOCKED card40 N)
+
+	(NOT-BLOCKED card39 W)
+	(NOT-BLOCKED card39 N)
+
+	(NOT-BLOCKED card38 S)
+	(NOT-BLOCKED card38 N)
+
+	(NOT-BLOCKED card37 W)
+	(NOT-BLOCKED card37 S)
+	(NOT-BLOCKED card37 N)
+
+	(NOT-BLOCKED card36 W)
+	(NOT-BLOCKED card36 E)
+	(NOT-BLOCKED card36 N)
+
+	(NOT-BLOCKED card35 E)
+	(NOT-BLOCKED card35 N)
+
+	(NOT-BLOCKED card34 W)
+	(NOT-BLOCKED card34 N)
+
+	(NOT-BLOCKED card33 W)
+	(NOT-BLOCKED card33 S)
+	(NOT-BLOCKED card33 N)
+
+	(NOT-BLOCKED card32 W)
+	(NOT-BLOCKED card32 S)
+	(NOT-BLOCKED card32 E)
+
+	(NOT-BLOCKED card31 W)
+	(NOT-BLOCKED card31 E)
+	(NOT-BLOCKED card31 N)
+
+	(NOT-BLOCKED card30 W)
+	(NOT-BLOCKED card30 S)
+	(NOT-BLOCKED card30 E)
+	(NOT-BLOCKED card30 N)
+
+	(NOT-BLOCKED card29 E)
+	(NOT-BLOCKED card29 N)
+
+	(NOT-BLOCKED card28 S)
+	(NOT-BLOCKED card28 E)
+
+	(NOT-BLOCKED card27 W)
+	(NOT-BLOCKED card27 S)
+
+	(NOT-BLOCKED card26 W)
+	(NOT-BLOCKED card26 E)
+	(NOT-BLOCKED card26 N)
+
+	(NOT-BLOCKED card25 W)
+	(NOT-BLOCKED card25 S)
+
+	(NOT-BLOCKED card24 S)
+	(NOT-BLOCKED card24 E)
+	(NOT-BLOCKED card24 N)
+
+	(NOT-BLOCKED card23 S)
+	(NOT-BLOCKED card23 E)
+	(NOT-BLOCKED card23 N)
+
+	(NOT-BLOCKED card22 W)
+	(NOT-BLOCKED card22 S)
+	(NOT-BLOCKED card22 N)
+
+	(NOT-BLOCKED card21 E)
+	(NOT-BLOCKED card21 N)
+
+	(NOT-BLOCKED card20 W)
+	(NOT-BLOCKED card20 S)
+
+	(NOT-BLOCKED card19 W)
+	(NOT-BLOCKED card19 E)
+	(NOT-BLOCKED card19 N)
+
+	(NOT-BLOCKED card18 W)
+	(NOT-BLOCKED card18 S)
+
+	(NOT-BLOCKED card17 W)
+	(NOT-BLOCKED card17 S)
+
+	(NOT-BLOCKED card16 E)
+	(NOT-BLOCKED card16 N)
+
+	(NOT-BLOCKED card15 E)
+	(NOT-BLOCKED card15 N)
+
+	(NOT-BLOCKED card14 W)
+	(NOT-BLOCKED card14 N)
+
+	(NOT-BLOCKED card13 S)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 S)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 W)
+	(NOT-BLOCKED card11 S)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 S)
+	(NOT-BLOCKED card10 E)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 W)
+	(NOT-BLOCKED card9 E)
+
+	(NOT-BLOCKED card8 S)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 W)
+	(NOT-BLOCKED card7 E)
+
+	(NOT-BLOCKED card6 S)
+	(NOT-BLOCKED card6 E)
+
+	(NOT-BLOCKED card5 W)
+	(NOT-BLOCKED card5 S)
+
+	(NOT-BLOCKED card4 W)
+	(NOT-BLOCKED card4 E)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 E)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 E)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 S)
+	(NOT-BLOCKED card1 E)
+
+	(NOT-BLOCKED card0 E)
+	(NOT-BLOCKED card0 N)
+
+	(MAX-POS pos7)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+	(NEXT pos6 pos5)
+	(NEXT pos7 pos6)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card10 pos2 pos0)
+	(card-at card59 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card5 pos5 pos0)
+	(card-at card6 pos6 pos0)
+	(card-at card7 pos7 pos0)
+	(card-at card8 pos0 pos1)
+	(card-at card9 pos1 pos1)
+	(card-at card18 pos2 pos1)
+	(card-at card3 pos3 pos1)
+	(card-at card12 pos4 pos1)
+	(card-at card13 pos5 pos1)
+	(card-at card14 pos6 pos1)
+	(card-at card15 pos7 pos1)
+	(card-at card16 pos0 pos2)
+	(card-at card17 pos1 pos2)
+	(card-at card26 pos2 pos2)
+	(card-at card11 pos3 pos2)
+	(card-at card20 pos4 pos2)
+	(card-at card21 pos5 pos2)
+	(card-at card22 pos6 pos2)
+	(card-at card23 pos7 pos2)
+	(card-at card24 pos0 pos3)
+	(card-at card25 pos1 pos3)
+	(card-at card34 pos2 pos3)
+	(card-at card19 pos3 pos3)
+	(card-at card28 pos4 pos3)
+	(card-at card29 pos5 pos3)
+	(card-at card30 pos6 pos3)
+	(card-at card31 pos7 pos3)
+	(card-at card39 pos0 pos4)
+	(card-at card32 pos1 pos4)
+	(card-at card33 pos2 pos4)
+	(card-at card42 pos3 pos4)
+	(card-at card27 pos4 pos4)
+	(card-at card36 pos5 pos4)
+	(card-at card37 pos6 pos4)
+	(card-at card38 pos7 pos4)
+	(card-at card40 pos0 pos5)
+	(card-at card41 pos1 pos5)
+	(card-at card50 pos2 pos5)
+	(card-at card35 pos3 pos5)
+	(card-at card44 pos4 pos5)
+	(card-at card45 pos5 pos5)
+	(card-at card46 pos6 pos5)
+	(card-at card47 pos7 pos5)
+	(card-at card48 pos0 pos6)
+	(card-at card49 pos1 pos6)
+	(card-at card58 pos2 pos6)
+	(card-at card43 pos3 pos6)
+	(card-at card52 pos4 pos6)
+	(card-at card53 pos5 pos6)
+	(card-at card54 pos6 pos6)
+	(card-at card55 pos7 pos6)
+	(card-at card56 pos0 pos7)
+	(card-at card57 pos1 pos7)
+	(card-at card2 pos2 pos7)
+	(card-at card51 pos3 pos7)
+	(card-at card60 pos4 pos7)
+	(card-at card61 pos5 pos7)
+	(card-at card62 pos6 pos7)
+	(card-at card63 pos7 pos7)
+
+	(BLOCKED card0 S)
+	(BLOCKED card0 W)
+
+	(BLOCKED card1 N)
+
+	(BLOCKED card10 W)
+
+	(BLOCKED card59 E)
+	(BLOCKED card59 W)
+
+	(BLOCKED card4 N)
+	(BLOCKED card4 S)
+
+	(BLOCKED card5 N)
+	(BLOCKED card5 E)
+
+	(BLOCKED card6 N)
+	(BLOCKED card6 W)
+
+	(BLOCKED card7 N)
+	(BLOCKED card7 S)
+
+	(BLOCKED card8 E)
+	(BLOCKED card8 W)
+
+	(BLOCKED card9 N)
+	(BLOCKED card9 S)
+
+	(BLOCKED card18 N)
+	(BLOCKED card18 E)
+
+	(BLOCKED card3 N)
+	(BLOCKED card3 S)
+
+	(BLOCKED card12 E)
+	(BLOCKED card12 W)
+
+	(BLOCKED card13 E)
+	(BLOCKED card13 W)
+
+	(BLOCKED card14 E)
+	(BLOCKED card14 S)
+
+	(BLOCKED card15 S)
+	(BLOCKED card15 W)
+
+	(BLOCKED card16 S)
+	(BLOCKED card16 W)
+
+	(BLOCKED card17 N)
+	(BLOCKED card17 E)
+
+	(BLOCKED card26 S)
+
+	(BLOCKED card11 E)
+
+	(BLOCKED card20 N)
+	(BLOCKED card20 E)
+
+	(BLOCKED card21 S)
+	(BLOCKED card21 W)
+
+	(BLOCKED card22 E)
+
+	(BLOCKED card23 W)
+
+	(BLOCKED card24 W)
+
+	(BLOCKED card25 N)
+	(BLOCKED card25 E)
+
+	(BLOCKED card34 E)
+	(BLOCKED card34 S)
+
+	(BLOCKED card19 S)
+
+	(BLOCKED card28 N)
+	(BLOCKED card28 W)
+
+	(BLOCKED card29 S)
+	(BLOCKED card29 W)
+
+
+	(BLOCKED card31 S)
+
+	(BLOCKED card39 E)
+	(BLOCKED card39 S)
+
+	(BLOCKED card32 N)
+
+	(BLOCKED card33 E)
+
+	(BLOCKED card42 W)
+
+	(BLOCKED card27 N)
+	(BLOCKED card27 E)
+
+	(BLOCKED card36 S)
+
+	(BLOCKED card37 E)
+
+	(BLOCKED card38 E)
+	(BLOCKED card38 W)
+
+	(BLOCKED card40 S)
+	(BLOCKED card40 W)
+
+	(BLOCKED card41 E)
+	(BLOCKED card41 S)
+
+	(BLOCKED card50 E)
+	(BLOCKED card50 W)
+
+	(BLOCKED card35 S)
+	(BLOCKED card35 W)
+
+	(BLOCKED card44 N)
+	(BLOCKED card44 W)
+
+	(BLOCKED card45 E)
+	(BLOCKED card45 S)
+
+	(BLOCKED card46 S)
+	(BLOCKED card46 W)
+
+	(BLOCKED card47 N)
+
+	(BLOCKED card48 S)
+	(BLOCKED card48 W)
+
+	(BLOCKED card49 E)
+
+	(BLOCKED card58 N)
+
+	(BLOCKED card43 N)
+	(BLOCKED card43 W)
+
+	(BLOCKED card52 S)
+	(BLOCKED card52 W)
+
+	(BLOCKED card53 N)
+	(BLOCKED card53 S)
+
+	(BLOCKED card54 S)
+
+	(BLOCKED card55 W)
+
+	(BLOCKED card56 S)
+
+	(BLOCKED card57 E)
+	(BLOCKED card57 W)
+
+	(BLOCKED card2 N)
+	(BLOCKED card2 S)
+
+	(BLOCKED card51 S)
+	(BLOCKED card51 W)
+
+
+	(BLOCKED card61 E)
+	(BLOCKED card61 W)
+
+	(BLOCKED card62 N)
+	(BLOCKED card62 E)
+
+	(BLOCKED card63 E)
+	(BLOCKED card63 W)
+
+
+	(robot-at card0)
+
+	(not-robot-at card63)
+	(not-robot-at card62)
+	(not-robot-at card61)
+	(not-robot-at card60)
+	(not-robot-at card59)
+	(not-robot-at card58)
+	(not-robot-at card57)
+	(not-robot-at card56)
+	(not-robot-at card55)
+	(not-robot-at card54)
+	(not-robot-at card53)
+	(not-robot-at card52)
+	(not-robot-at card51)
+	(not-robot-at card50)
+	(not-robot-at card49)
+	(not-robot-at card48)
+	(not-robot-at card47)
+	(not-robot-at card46)
+	(not-robot-at card45)
+	(not-robot-at card44)
+	(not-robot-at card43)
+	(not-robot-at card42)
+	(not-robot-at card41)
+	(not-robot-at card40)
+	(not-robot-at card39)
+	(not-robot-at card38)
+	(not-robot-at card37)
+	(not-robot-at card36)
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/SAT/p19.pddl
+++ b/labyrinth/SAT/p19.pddl
@@ -1,0 +1,546 @@
+;; Generated with seed: 1367, size: 8, num-rotations: 4
+(define (problem labyrinth-size-8-rotations-4-seed-1367)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5 pos6 pos7  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35 card36 card37 card38 card39 card40 card41 card42 card43 card44 card45 card46 card47 card48 card49 card50 card51 card52 card53 card54 card55 card56 card57 card58 card59 card60 card61 card62 card63  - card
+)
+(:init
+	(NOT-BLOCKED card63 W)
+	(NOT-BLOCKED card63 S)
+
+	(NOT-BLOCKED card62 W)
+	(NOT-BLOCKED card62 E)
+
+	(NOT-BLOCKED card61 W)
+	(NOT-BLOCKED card61 E)
+	(NOT-BLOCKED card61 N)
+
+	(NOT-BLOCKED card60 W)
+	(NOT-BLOCKED card60 E)
+
+	(NOT-BLOCKED card59 S)
+	(NOT-BLOCKED card59 E)
+
+	(NOT-BLOCKED card58 S)
+	(NOT-BLOCKED card58 E)
+	(NOT-BLOCKED card58 N)
+
+	(NOT-BLOCKED card57 S)
+	(NOT-BLOCKED card57 E)
+
+	(NOT-BLOCKED card56 S)
+	(NOT-BLOCKED card56 E)
+	(NOT-BLOCKED card56 N)
+
+	(NOT-BLOCKED card55 W)
+	(NOT-BLOCKED card55 S)
+	(NOT-BLOCKED card55 E)
+
+	(NOT-BLOCKED card54 W)
+	(NOT-BLOCKED card54 S)
+	(NOT-BLOCKED card54 E)
+	(NOT-BLOCKED card54 N)
+
+	(NOT-BLOCKED card53 S)
+	(NOT-BLOCKED card53 N)
+
+	(NOT-BLOCKED card52 W)
+	(NOT-BLOCKED card52 E)
+
+	(NOT-BLOCKED card51 S)
+	(NOT-BLOCKED card51 N)
+
+	(NOT-BLOCKED card50 S)
+	(NOT-BLOCKED card50 E)
+
+	(NOT-BLOCKED card49 W)
+	(NOT-BLOCKED card49 S)
+	(NOT-BLOCKED card49 N)
+
+	(NOT-BLOCKED card48 S)
+	(NOT-BLOCKED card48 E)
+	(NOT-BLOCKED card48 N)
+
+	(NOT-BLOCKED card47 S)
+	(NOT-BLOCKED card47 N)
+
+	(NOT-BLOCKED card46 S)
+	(NOT-BLOCKED card46 E)
+
+	(NOT-BLOCKED card45 W)
+	(NOT-BLOCKED card45 S)
+
+	(NOT-BLOCKED card44 W)
+	(NOT-BLOCKED card44 E)
+	(NOT-BLOCKED card44 N)
+
+	(NOT-BLOCKED card43 W)
+	(NOT-BLOCKED card43 S)
+
+	(NOT-BLOCKED card42 S)
+	(NOT-BLOCKED card42 E)
+	(NOT-BLOCKED card42 N)
+
+	(NOT-BLOCKED card41 W)
+	(NOT-BLOCKED card41 E)
+
+	(NOT-BLOCKED card40 S)
+	(NOT-BLOCKED card40 N)
+
+	(NOT-BLOCKED card39 S)
+	(NOT-BLOCKED card39 N)
+
+	(NOT-BLOCKED card38 W)
+	(NOT-BLOCKED card38 N)
+
+	(NOT-BLOCKED card37 W)
+	(NOT-BLOCKED card37 N)
+
+	(NOT-BLOCKED card36 W)
+	(NOT-BLOCKED card36 S)
+	(NOT-BLOCKED card36 N)
+
+	(NOT-BLOCKED card35 E)
+	(NOT-BLOCKED card35 N)
+
+	(NOT-BLOCKED card34 S)
+	(NOT-BLOCKED card34 E)
+
+	(NOT-BLOCKED card33 W)
+	(NOT-BLOCKED card33 S)
+	(NOT-BLOCKED card33 N)
+
+	(NOT-BLOCKED card32 W)
+	(NOT-BLOCKED card32 E)
+
+	(NOT-BLOCKED card31 W)
+	(NOT-BLOCKED card31 S)
+	(NOT-BLOCKED card31 E)
+
+	(NOT-BLOCKED card30 S)
+	(NOT-BLOCKED card30 E)
+
+	(NOT-BLOCKED card29 W)
+	(NOT-BLOCKED card29 E)
+
+	(NOT-BLOCKED card28 E)
+	(NOT-BLOCKED card28 N)
+
+	(NOT-BLOCKED card27 S)
+	(NOT-BLOCKED card27 N)
+
+	(NOT-BLOCKED card26 W)
+	(NOT-BLOCKED card26 N)
+
+	(NOT-BLOCKED card25 W)
+	(NOT-BLOCKED card25 N)
+
+	(NOT-BLOCKED card24 W)
+	(NOT-BLOCKED card24 S)
+
+	(NOT-BLOCKED card23 W)
+	(NOT-BLOCKED card23 S)
+	(NOT-BLOCKED card23 N)
+
+	(NOT-BLOCKED card22 W)
+	(NOT-BLOCKED card22 S)
+
+	(NOT-BLOCKED card21 W)
+	(NOT-BLOCKED card21 N)
+
+	(NOT-BLOCKED card20 S)
+	(NOT-BLOCKED card20 E)
+	(NOT-BLOCKED card20 N)
+
+	(NOT-BLOCKED card19 W)
+	(NOT-BLOCKED card19 S)
+
+	(NOT-BLOCKED card18 W)
+	(NOT-BLOCKED card18 S)
+	(NOT-BLOCKED card18 E)
+	(NOT-BLOCKED card18 N)
+
+	(NOT-BLOCKED card17 S)
+	(NOT-BLOCKED card17 E)
+	(NOT-BLOCKED card17 N)
+
+	(NOT-BLOCKED card16 E)
+	(NOT-BLOCKED card16 N)
+
+	(NOT-BLOCKED card15 W)
+	(NOT-BLOCKED card15 S)
+
+	(NOT-BLOCKED card14 E)
+	(NOT-BLOCKED card14 N)
+
+	(NOT-BLOCKED card13 W)
+	(NOT-BLOCKED card13 N)
+
+	(NOT-BLOCKED card12 W)
+	(NOT-BLOCKED card12 S)
+
+	(NOT-BLOCKED card11 W)
+	(NOT-BLOCKED card11 E)
+
+	(NOT-BLOCKED card10 S)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 W)
+	(NOT-BLOCKED card9 S)
+	(NOT-BLOCKED card9 E)
+
+	(NOT-BLOCKED card8 E)
+	(NOT-BLOCKED card8 N)
+
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 W)
+	(NOT-BLOCKED card6 S)
+	(NOT-BLOCKED card6 E)
+
+	(NOT-BLOCKED card5 W)
+	(NOT-BLOCKED card5 S)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 S)
+	(NOT-BLOCKED card4 N)
+
+	(NOT-BLOCKED card3 S)
+	(NOT-BLOCKED card3 E)
+	(NOT-BLOCKED card3 N)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 S)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 S)
+	(NOT-BLOCKED card1 E)
+
+	(NOT-BLOCKED card0 S)
+	(NOT-BLOCKED card0 E)
+
+	(MAX-POS pos7)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+	(NEXT pos6 pos5)
+	(NEXT pos7 pos6)
+
+	(card-at card0 pos0 pos0)
+	(card-at card1 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card11 pos3 pos0)
+	(card-at card60 pos4 pos0)
+	(card-at card13 pos5 pos0)
+	(card-at card62 pos6 pos0)
+	(card-at card7 pos7 pos0)
+	(card-at card8 pos0 pos1)
+	(card-at card9 pos1 pos1)
+	(card-at card10 pos2 pos1)
+	(card-at card19 pos3 pos1)
+	(card-at card4 pos4 pos1)
+	(card-at card21 pos5 pos1)
+	(card-at card6 pos6 pos1)
+	(card-at card15 pos7 pos1)
+	(card-at card16 pos0 pos2)
+	(card-at card17 pos1 pos2)
+	(card-at card18 pos2 pos2)
+	(card-at card27 pos3 pos2)
+	(card-at card12 pos4 pos2)
+	(card-at card29 pos5 pos2)
+	(card-at card14 pos6 pos2)
+	(card-at card23 pos7 pos2)
+	(card-at card24 pos0 pos3)
+	(card-at card25 pos1 pos3)
+	(card-at card26 pos2 pos3)
+	(card-at card35 pos3 pos3)
+	(card-at card20 pos4 pos3)
+	(card-at card37 pos5 pos3)
+	(card-at card22 pos6 pos3)
+	(card-at card31 pos7 pos3)
+	(card-at card32 pos0 pos4)
+	(card-at card33 pos1 pos4)
+	(card-at card34 pos2 pos4)
+	(card-at card43 pos3 pos4)
+	(card-at card28 pos4 pos4)
+	(card-at card45 pos5 pos4)
+	(card-at card30 pos6 pos4)
+	(card-at card39 pos7 pos4)
+	(card-at card40 pos0 pos5)
+	(card-at card41 pos1 pos5)
+	(card-at card42 pos2 pos5)
+	(card-at card51 pos3 pos5)
+	(card-at card36 pos4 pos5)
+	(card-at card53 pos5 pos5)
+	(card-at card38 pos6 pos5)
+	(card-at card47 pos7 pos5)
+	(card-at card48 pos0 pos6)
+	(card-at card49 pos1 pos6)
+	(card-at card50 pos2 pos6)
+	(card-at card59 pos3 pos6)
+	(card-at card44 pos4 pos6)
+	(card-at card61 pos5 pos6)
+	(card-at card46 pos6 pos6)
+	(card-at card55 pos7 pos6)
+	(card-at card56 pos0 pos7)
+	(card-at card57 pos1 pos7)
+	(card-at card58 pos2 pos7)
+	(card-at card3 pos3 pos7)
+	(card-at card52 pos4 pos7)
+	(card-at card5 pos5 pos7)
+	(card-at card54 pos6 pos7)
+	(card-at card63 pos7 pos7)
+
+	(BLOCKED card0 N)
+	(BLOCKED card0 W)
+
+	(BLOCKED card1 N)
+
+	(BLOCKED card2 N)
+	(BLOCKED card2 E)
+
+	(BLOCKED card11 N)
+	(BLOCKED card11 S)
+
+	(BLOCKED card60 N)
+	(BLOCKED card60 S)
+
+	(BLOCKED card13 E)
+	(BLOCKED card13 S)
+
+	(BLOCKED card62 N)
+	(BLOCKED card62 S)
+
+	(BLOCKED card7 E)
+	(BLOCKED card7 W)
+
+	(BLOCKED card8 S)
+	(BLOCKED card8 W)
+
+	(BLOCKED card9 N)
+
+	(BLOCKED card10 E)
+	(BLOCKED card10 W)
+
+	(BLOCKED card19 N)
+	(BLOCKED card19 E)
+
+	(BLOCKED card4 E)
+	(BLOCKED card4 W)
+
+	(BLOCKED card21 E)
+	(BLOCKED card21 S)
+
+	(BLOCKED card6 N)
+
+	(BLOCKED card15 N)
+	(BLOCKED card15 E)
+
+	(BLOCKED card16 S)
+	(BLOCKED card16 W)
+
+	(BLOCKED card17 W)
+
+
+	(BLOCKED card27 E)
+	(BLOCKED card27 W)
+
+	(BLOCKED card12 N)
+	(BLOCKED card12 E)
+
+	(BLOCKED card29 N)
+	(BLOCKED card29 S)
+
+	(BLOCKED card14 S)
+	(BLOCKED card14 W)
+
+	(BLOCKED card23 E)
+
+	(BLOCKED card24 N)
+	(BLOCKED card24 E)
+
+	(BLOCKED card25 E)
+	(BLOCKED card25 S)
+
+	(BLOCKED card26 E)
+	(BLOCKED card26 S)
+
+	(BLOCKED card35 S)
+	(BLOCKED card35 W)
+
+	(BLOCKED card20 W)
+
+	(BLOCKED card37 E)
+	(BLOCKED card37 S)
+
+	(BLOCKED card22 N)
+	(BLOCKED card22 E)
+
+	(BLOCKED card31 N)
+
+	(BLOCKED card32 N)
+	(BLOCKED card32 S)
+
+	(BLOCKED card33 E)
+
+	(BLOCKED card34 N)
+	(BLOCKED card34 W)
+
+	(BLOCKED card43 N)
+	(BLOCKED card43 E)
+
+	(BLOCKED card28 S)
+	(BLOCKED card28 W)
+
+	(BLOCKED card45 N)
+	(BLOCKED card45 E)
+
+	(BLOCKED card30 N)
+	(BLOCKED card30 W)
+
+	(BLOCKED card39 E)
+	(BLOCKED card39 W)
+
+	(BLOCKED card40 E)
+	(BLOCKED card40 W)
+
+	(BLOCKED card41 N)
+	(BLOCKED card41 S)
+
+	(BLOCKED card42 W)
+
+	(BLOCKED card51 E)
+	(BLOCKED card51 W)
+
+	(BLOCKED card36 E)
+
+	(BLOCKED card53 E)
+	(BLOCKED card53 W)
+
+	(BLOCKED card38 E)
+	(BLOCKED card38 S)
+
+	(BLOCKED card47 E)
+	(BLOCKED card47 W)
+
+	(BLOCKED card48 W)
+
+	(BLOCKED card49 E)
+
+	(BLOCKED card50 N)
+	(BLOCKED card50 W)
+
+	(BLOCKED card59 N)
+	(BLOCKED card59 W)
+
+	(BLOCKED card44 S)
+
+	(BLOCKED card61 S)
+
+	(BLOCKED card46 N)
+	(BLOCKED card46 W)
+
+	(BLOCKED card55 N)
+
+	(BLOCKED card56 W)
+
+	(BLOCKED card57 N)
+	(BLOCKED card57 W)
+
+	(BLOCKED card58 W)
+
+	(BLOCKED card3 W)
+
+	(BLOCKED card52 N)
+	(BLOCKED card52 S)
+
+	(BLOCKED card5 E)
+
+
+	(BLOCKED card63 N)
+	(BLOCKED card63 E)
+
+
+	(robot-at card0)
+
+	(not-robot-at card63)
+	(not-robot-at card62)
+	(not-robot-at card61)
+	(not-robot-at card60)
+	(not-robot-at card59)
+	(not-robot-at card58)
+	(not-robot-at card57)
+	(not-robot-at card56)
+	(not-robot-at card55)
+	(not-robot-at card54)
+	(not-robot-at card53)
+	(not-robot-at card52)
+	(not-robot-at card51)
+	(not-robot-at card50)
+	(not-robot-at card49)
+	(not-robot-at card48)
+	(not-robot-at card47)
+	(not-robot-at card46)
+	(not-robot-at card45)
+	(not-robot-at card44)
+	(not-robot-at card43)
+	(not-robot-at card42)
+	(not-robot-at card41)
+	(not-robot-at card40)
+	(not-robot-at card39)
+	(not-robot-at card38)
+	(not-robot-at card37)
+	(not-robot-at card36)
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/labyrinth/SAT/p20.pddl
+++ b/labyrinth/SAT/p20.pddl
@@ -1,0 +1,546 @@
+;; Generated with seed: 1373, size: 8, num-rotations: 6
+(define (problem labyrinth-size-8-rotations-6-seed-1373)
+(:domain labyrinth)
+(:objects
+	pos0 pos1 pos2 pos3 pos4 pos5 pos6 pos7  - gridpos
+	card0 card1 card2 card3 card4 card5 card6 card7 card8 card9 card10 card11 card12 card13 card14 card15 card16 card17 card18 card19 card20 card21 card22 card23 card24 card25 card26 card27 card28 card29 card30 card31 card32 card33 card34 card35 card36 card37 card38 card39 card40 card41 card42 card43 card44 card45 card46 card47 card48 card49 card50 card51 card52 card53 card54 card55 card56 card57 card58 card59 card60 card61 card62 card63  - card
+)
+(:init
+	(NOT-BLOCKED card63 S)
+	(NOT-BLOCKED card63 N)
+
+	(NOT-BLOCKED card62 W)
+	(NOT-BLOCKED card62 S)
+	(NOT-BLOCKED card62 E)
+
+	(NOT-BLOCKED card61 W)
+	(NOT-BLOCKED card61 N)
+
+	(NOT-BLOCKED card60 W)
+	(NOT-BLOCKED card60 E)
+
+	(NOT-BLOCKED card59 E)
+	(NOT-BLOCKED card59 N)
+
+	(NOT-BLOCKED card58 S)
+	(NOT-BLOCKED card58 N)
+
+	(NOT-BLOCKED card57 S)
+	(NOT-BLOCKED card57 N)
+
+	(NOT-BLOCKED card56 W)
+	(NOT-BLOCKED card56 S)
+	(NOT-BLOCKED card56 E)
+
+	(NOT-BLOCKED card55 W)
+	(NOT-BLOCKED card55 S)
+
+	(NOT-BLOCKED card54 W)
+	(NOT-BLOCKED card54 S)
+	(NOT-BLOCKED card54 E)
+
+	(NOT-BLOCKED card53 S)
+	(NOT-BLOCKED card53 E)
+	(NOT-BLOCKED card53 N)
+
+	(NOT-BLOCKED card52 S)
+	(NOT-BLOCKED card52 E)
+
+	(NOT-BLOCKED card51 W)
+	(NOT-BLOCKED card51 S)
+
+	(NOT-BLOCKED card50 W)
+	(NOT-BLOCKED card50 N)
+
+	(NOT-BLOCKED card49 S)
+	(NOT-BLOCKED card49 N)
+
+	(NOT-BLOCKED card48 W)
+	(NOT-BLOCKED card48 S)
+
+	(NOT-BLOCKED card47 S)
+	(NOT-BLOCKED card47 N)
+
+	(NOT-BLOCKED card46 S)
+	(NOT-BLOCKED card46 E)
+
+	(NOT-BLOCKED card45 W)
+	(NOT-BLOCKED card45 S)
+
+	(NOT-BLOCKED card44 W)
+	(NOT-BLOCKED card44 S)
+	(NOT-BLOCKED card44 E)
+
+	(NOT-BLOCKED card43 E)
+	(NOT-BLOCKED card43 N)
+
+	(NOT-BLOCKED card42 W)
+	(NOT-BLOCKED card42 S)
+
+	(NOT-BLOCKED card41 W)
+	(NOT-BLOCKED card41 E)
+
+	(NOT-BLOCKED card40 W)
+	(NOT-BLOCKED card40 E)
+
+	(NOT-BLOCKED card39 E)
+	(NOT-BLOCKED card39 N)
+
+	(NOT-BLOCKED card38 S)
+	(NOT-BLOCKED card38 E)
+
+	(NOT-BLOCKED card37 E)
+	(NOT-BLOCKED card37 N)
+
+	(NOT-BLOCKED card36 W)
+	(NOT-BLOCKED card36 S)
+	(NOT-BLOCKED card36 E)
+
+	(NOT-BLOCKED card35 S)
+	(NOT-BLOCKED card35 N)
+
+	(NOT-BLOCKED card34 W)
+	(NOT-BLOCKED card34 S)
+
+	(NOT-BLOCKED card33 S)
+	(NOT-BLOCKED card33 E)
+
+	(NOT-BLOCKED card32 W)
+	(NOT-BLOCKED card32 S)
+
+	(NOT-BLOCKED card31 W)
+	(NOT-BLOCKED card31 S)
+
+	(NOT-BLOCKED card30 W)
+	(NOT-BLOCKED card30 S)
+	(NOT-BLOCKED card30 N)
+
+	(NOT-BLOCKED card29 W)
+	(NOT-BLOCKED card29 E)
+
+	(NOT-BLOCKED card28 S)
+	(NOT-BLOCKED card28 E)
+
+	(NOT-BLOCKED card27 W)
+	(NOT-BLOCKED card27 S)
+	(NOT-BLOCKED card27 N)
+
+	(NOT-BLOCKED card26 W)
+	(NOT-BLOCKED card26 S)
+	(NOT-BLOCKED card26 E)
+
+	(NOT-BLOCKED card25 S)
+	(NOT-BLOCKED card25 E)
+	(NOT-BLOCKED card25 N)
+
+	(NOT-BLOCKED card24 W)
+	(NOT-BLOCKED card24 E)
+
+	(NOT-BLOCKED card23 S)
+	(NOT-BLOCKED card23 E)
+
+	(NOT-BLOCKED card22 W)
+	(NOT-BLOCKED card22 E)
+	(NOT-BLOCKED card22 N)
+
+	(NOT-BLOCKED card21 S)
+	(NOT-BLOCKED card21 E)
+
+	(NOT-BLOCKED card20 S)
+	(NOT-BLOCKED card20 E)
+
+	(NOT-BLOCKED card19 S)
+	(NOT-BLOCKED card19 N)
+
+	(NOT-BLOCKED card18 S)
+	(NOT-BLOCKED card18 N)
+
+	(NOT-BLOCKED card17 W)
+	(NOT-BLOCKED card17 S)
+
+	(NOT-BLOCKED card16 E)
+	(NOT-BLOCKED card16 N)
+
+	(NOT-BLOCKED card15 W)
+	(NOT-BLOCKED card15 S)
+	(NOT-BLOCKED card15 E)
+
+	(NOT-BLOCKED card14 W)
+	(NOT-BLOCKED card14 E)
+
+	(NOT-BLOCKED card13 S)
+	(NOT-BLOCKED card13 E)
+
+	(NOT-BLOCKED card12 W)
+	(NOT-BLOCKED card12 N)
+
+	(NOT-BLOCKED card11 W)
+	(NOT-BLOCKED card11 N)
+
+	(NOT-BLOCKED card10 W)
+	(NOT-BLOCKED card10 N)
+
+	(NOT-BLOCKED card9 W)
+	(NOT-BLOCKED card9 E)
+
+	(NOT-BLOCKED card8 S)
+	(NOT-BLOCKED card8 E)
+
+	(NOT-BLOCKED card7 S)
+	(NOT-BLOCKED card7 E)
+	(NOT-BLOCKED card7 N)
+
+	(NOT-BLOCKED card6 W)
+	(NOT-BLOCKED card6 S)
+	(NOT-BLOCKED card6 E)
+	(NOT-BLOCKED card6 N)
+
+	(NOT-BLOCKED card5 E)
+	(NOT-BLOCKED card5 N)
+
+	(NOT-BLOCKED card4 E)
+	(NOT-BLOCKED card4 N)
+
+	(NOT-BLOCKED card3 W)
+	(NOT-BLOCKED card3 S)
+
+	(NOT-BLOCKED card2 W)
+	(NOT-BLOCKED card2 S)
+
+	(NOT-BLOCKED card1 W)
+	(NOT-BLOCKED card1 E)
+
+	(NOT-BLOCKED card0 W)
+	(NOT-BLOCKED card0 E)
+	(NOT-BLOCKED card0 N)
+
+	(MAX-POS pos7)
+	(MIN-POS pos0)
+
+	(NEXT pos1 pos0)
+	(NEXT pos2 pos1)
+	(NEXT pos3 pos2)
+	(NEXT pos4 pos3)
+	(NEXT pos5 pos4)
+	(NEXT pos6 pos5)
+	(NEXT pos7 pos6)
+
+	(card-at card0 pos0 pos0)
+	(card-at card57 pos1 pos0)
+	(card-at card2 pos2 pos0)
+	(card-at card3 pos3 pos0)
+	(card-at card4 pos4 pos0)
+	(card-at card12 pos5 pos0)
+	(card-at card6 pos6 pos0)
+	(card-at card7 pos7 pos0)
+	(card-at card15 pos0 pos1)
+	(card-at card8 pos1 pos1)
+	(card-at card1 pos2 pos1)
+	(card-at card10 pos3 pos1)
+	(card-at card11 pos4 pos1)
+	(card-at card21 pos5 pos1)
+	(card-at card13 pos6 pos1)
+	(card-at card14 pos7 pos1)
+	(card-at card16 pos0 pos2)
+	(card-at card9 pos1 pos2)
+	(card-at card18 pos2 pos2)
+	(card-at card19 pos3 pos2)
+	(card-at card20 pos4 pos2)
+	(card-at card30 pos5 pos2)
+	(card-at card22 pos6 pos2)
+	(card-at card23 pos7 pos2)
+	(card-at card17 pos0 pos3)
+	(card-at card26 pos1 pos3)
+	(card-at card27 pos2 pos3)
+	(card-at card28 pos3 pos3)
+	(card-at card29 pos4 pos3)
+	(card-at card38 pos5 pos3)
+	(card-at card31 pos6 pos3)
+	(card-at card24 pos7 pos3)
+	(card-at card33 pos0 pos4)
+	(card-at card25 pos1 pos4)
+	(card-at card35 pos2 pos4)
+	(card-at card36 pos3 pos4)
+	(card-at card37 pos4 pos4)
+	(card-at card46 pos5 pos4)
+	(card-at card39 pos6 pos4)
+	(card-at card32 pos7 pos4)
+	(card-at card34 pos0 pos5)
+	(card-at card42 pos1 pos5)
+	(card-at card43 pos2 pos5)
+	(card-at card44 pos3 pos5)
+	(card-at card45 pos4 pos5)
+	(card-at card53 pos5 pos5)
+	(card-at card47 pos6 pos5)
+	(card-at card40 pos7 pos5)
+	(card-at card48 pos0 pos6)
+	(card-at card41 pos1 pos6)
+	(card-at card50 pos2 pos6)
+	(card-at card51 pos3 pos6)
+	(card-at card52 pos4 pos6)
+	(card-at card61 pos5 pos6)
+	(card-at card54 pos6 pos6)
+	(card-at card55 pos7 pos6)
+	(card-at card56 pos0 pos7)
+	(card-at card49 pos1 pos7)
+	(card-at card58 pos2 pos7)
+	(card-at card59 pos3 pos7)
+	(card-at card60 pos4 pos7)
+	(card-at card5 pos5 pos7)
+	(card-at card62 pos6 pos7)
+	(card-at card63 pos7 pos7)
+
+	(BLOCKED card0 S)
+
+	(BLOCKED card57 E)
+	(BLOCKED card57 W)
+
+	(BLOCKED card2 N)
+	(BLOCKED card2 E)
+
+	(BLOCKED card3 N)
+	(BLOCKED card3 E)
+
+	(BLOCKED card4 S)
+	(BLOCKED card4 W)
+
+	(BLOCKED card12 E)
+	(BLOCKED card12 S)
+
+
+	(BLOCKED card7 W)
+
+	(BLOCKED card15 N)
+
+	(BLOCKED card8 N)
+	(BLOCKED card8 W)
+
+	(BLOCKED card1 N)
+	(BLOCKED card1 S)
+
+	(BLOCKED card10 E)
+	(BLOCKED card10 S)
+
+	(BLOCKED card11 E)
+	(BLOCKED card11 S)
+
+	(BLOCKED card21 N)
+	(BLOCKED card21 W)
+
+	(BLOCKED card13 N)
+	(BLOCKED card13 W)
+
+	(BLOCKED card14 N)
+	(BLOCKED card14 S)
+
+	(BLOCKED card16 S)
+	(BLOCKED card16 W)
+
+	(BLOCKED card9 N)
+	(BLOCKED card9 S)
+
+	(BLOCKED card18 E)
+	(BLOCKED card18 W)
+
+	(BLOCKED card19 E)
+	(BLOCKED card19 W)
+
+	(BLOCKED card20 N)
+	(BLOCKED card20 W)
+
+	(BLOCKED card30 E)
+
+	(BLOCKED card22 S)
+
+	(BLOCKED card23 N)
+	(BLOCKED card23 W)
+
+	(BLOCKED card17 N)
+	(BLOCKED card17 E)
+
+	(BLOCKED card26 N)
+
+	(BLOCKED card27 E)
+
+	(BLOCKED card28 N)
+	(BLOCKED card28 W)
+
+	(BLOCKED card29 N)
+	(BLOCKED card29 S)
+
+	(BLOCKED card38 N)
+	(BLOCKED card38 W)
+
+	(BLOCKED card31 N)
+	(BLOCKED card31 E)
+
+	(BLOCKED card24 N)
+	(BLOCKED card24 S)
+
+	(BLOCKED card33 N)
+	(BLOCKED card33 W)
+
+	(BLOCKED card25 W)
+
+	(BLOCKED card35 E)
+	(BLOCKED card35 W)
+
+	(BLOCKED card36 N)
+
+	(BLOCKED card37 S)
+	(BLOCKED card37 W)
+
+	(BLOCKED card46 N)
+	(BLOCKED card46 W)
+
+	(BLOCKED card39 S)
+	(BLOCKED card39 W)
+
+	(BLOCKED card32 N)
+	(BLOCKED card32 E)
+
+	(BLOCKED card34 N)
+	(BLOCKED card34 E)
+
+	(BLOCKED card42 N)
+	(BLOCKED card42 E)
+
+	(BLOCKED card43 S)
+	(BLOCKED card43 W)
+
+	(BLOCKED card44 N)
+
+	(BLOCKED card45 N)
+	(BLOCKED card45 E)
+
+	(BLOCKED card53 W)
+
+	(BLOCKED card47 E)
+	(BLOCKED card47 W)
+
+	(BLOCKED card40 N)
+	(BLOCKED card40 S)
+
+	(BLOCKED card48 N)
+	(BLOCKED card48 E)
+
+	(BLOCKED card41 N)
+	(BLOCKED card41 S)
+
+	(BLOCKED card50 E)
+	(BLOCKED card50 S)
+
+	(BLOCKED card51 N)
+	(BLOCKED card51 E)
+
+	(BLOCKED card52 N)
+	(BLOCKED card52 W)
+
+	(BLOCKED card61 E)
+	(BLOCKED card61 S)
+
+	(BLOCKED card54 N)
+
+	(BLOCKED card55 N)
+	(BLOCKED card55 E)
+
+	(BLOCKED card56 N)
+
+	(BLOCKED card49 E)
+	(BLOCKED card49 W)
+
+	(BLOCKED card58 E)
+	(BLOCKED card58 W)
+
+	(BLOCKED card59 S)
+	(BLOCKED card59 W)
+
+	(BLOCKED card60 N)
+	(BLOCKED card60 S)
+
+	(BLOCKED card5 S)
+	(BLOCKED card5 W)
+
+	(BLOCKED card62 N)
+
+	(BLOCKED card63 E)
+	(BLOCKED card63 W)
+
+
+	(robot-at card0)
+
+	(not-robot-at card63)
+	(not-robot-at card62)
+	(not-robot-at card61)
+	(not-robot-at card60)
+	(not-robot-at card59)
+	(not-robot-at card58)
+	(not-robot-at card57)
+	(not-robot-at card56)
+	(not-robot-at card55)
+	(not-robot-at card54)
+	(not-robot-at card53)
+	(not-robot-at card52)
+	(not-robot-at card51)
+	(not-robot-at card50)
+	(not-robot-at card49)
+	(not-robot-at card48)
+	(not-robot-at card47)
+	(not-robot-at card46)
+	(not-robot-at card45)
+	(not-robot-at card44)
+	(not-robot-at card43)
+	(not-robot-at card42)
+	(not-robot-at card41)
+	(not-robot-at card40)
+	(not-robot-at card39)
+	(not-robot-at card38)
+	(not-robot-at card37)
+	(not-robot-at card36)
+	(not-robot-at card35)
+	(not-robot-at card34)
+	(not-robot-at card33)
+	(not-robot-at card32)
+	(not-robot-at card31)
+	(not-robot-at card30)
+	(not-robot-at card29)
+	(not-robot-at card28)
+	(not-robot-at card27)
+	(not-robot-at card26)
+	(not-robot-at card25)
+	(not-robot-at card24)
+	(not-robot-at card23)
+	(not-robot-at card22)
+	(not-robot-at card21)
+	(not-robot-at card20)
+	(not-robot-at card19)
+	(not-robot-at card18)
+	(not-robot-at card17)
+	(not-robot-at card16)
+	(not-robot-at card15)
+	(not-robot-at card14)
+	(not-robot-at card13)
+	(not-robot-at card12)
+	(not-robot-at card11)
+	(not-robot-at card10)
+	(not-robot-at card9)
+	(not-robot-at card8)
+	(not-robot-at card7)
+	(not-robot-at card6)
+	(not-robot-at card5)
+	(not-robot-at card4)
+	(not-robot-at card3)
+	(not-robot-at card2)
+	(not-robot-at card1)
+	(not-cards-moving)
+	(= (total-cost) 0)
+	(= (move-robot-cost) 1)
+	(= (move-card) 1)
+)
+(:goal
+	(and
+		(left)
+	)
+)
+	(:metric minimize (total-cost))
+)

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 seem to correspond to the easiest instances of the `-split` version here.
 
 * The `organic-synthesis` benchmarks are different versions of the same problem. The instances
-appearing in the IPC'18 are no exactly these ones, but simpler instances.
+appearing in the IPC'18 are not exactly these ones, but simpler instances.
 
 * The `pipesworld-tankage-nosplit` folder contains the *non-split* version of the
 `pipesworld-tankage`, as it features e.g. in the downward-benchmark repos.
@@ -25,6 +25,8 @@ sourced from
 * The `visitall-multidimensional` folder contains an extension of the original visitall domain that interchanges the 2D-grid with a n-dimensional hypercube.
 
 * The `*-large-simple` folders contain larger instances of standard benchmarks with a low goal amount.
+
+* The `labyrinth` folder contains the SAT and OPT set of the labyrinth domain from the [IPC2023 dataset](https://github.com/ipc2023-classical/ipc2023-dataset/tree/main). The domain has been altered to include no negative preconditions
 
 ## Scripts
 


### PR DESCRIPTION
This adds the labyrinth domain from IPC2023 which is hard to ground (~4GB @ 5x5, 16+ GB @ 6x6).

I altered the domain by Rebecca Eifler and Daniel Fišer ([generator](https://github.com/ipc2023-classical/domain-labyrinth/tree/main)) to include no negative preconditions, allowing it to be used with powerlifted etc. Except for the altered domain, the problems are the same ones used in the SAT and OPT tracks of the IPC2023, separated by a folder.

I removed the given plans and images that are included in the [actual dataset](https://github.com/ipc2023-classical/ipc2023-dataset/tree/main), because the other domains in this repo also only contain problem files and a domain file. 

To ensure that the conversion process did not change the domain, I have validated several plans that were generated for the old domain on the altered one and they all validated correctly. I also tested a few plans generated for the altered domain on the problems of the unaltered domain and those validated correctly as well.

The flatten-structure.py is also changed to include the new domain and a description is added in the readme.